### PR TITLE
Added YAML options

### DIFF
--- a/worlds/another_crab/__init__.py
+++ b/worlds/another_crab/__init__.py
@@ -7,7 +7,7 @@ from .locations import location_table, location_name_groups, location_name_to_id
 from .regions import ACT_regions
 from .rules import set_location_rules, set_region_rules
 from .options import ACTGameOptions
-from .names import location_names as lname
+from .names import location_names as lname, item_names as iname, region_names as rname
 
 
 class ACTWeb(WebWorld):
@@ -41,18 +41,32 @@ class ACTWorld(World):
 
     def create_items(self) -> None:
         ACT_items: List[ACTItem] = []
-        remove_costumes = self.options.removeCostumes
         costume_list = costume_items
         #self.slot_data_items = []
 
         items_to_create: Dict[str, int] = {item: data.quantity_in_item_pool for item, data in item_table.items()}
 
+        if self.options.forkLocation:
+            fork = self.create_item(iname.fork)
+            if self.options.forkLocation == "vanilla_location":
+                self.multiworld.get_location(lname.fork_pickup, self.player).place_locked_item(fork)
+            items_to_create[iname.fork] = 0
+
+        if self.options.shelleportLocation:
+            shelleport = self.create_item(iname.shelleport)
+            if self.options.shelleportLocation == "starting_items":
+                self.multiworld.push_precollected(shelleport)
+            elif self.options.shelleportLocation == "vanilla_location":
+                self.multiworld.get_location(lname.shelleport_skill, self.player).place_locked_item(shelleport)
+            items_to_create[iname.shelleport] = 0
+
+        if self.options.removeCostumes:
+            items_to_create[costume_list] = 0
+
         for item, quantity in items_to_create.items():
             for i in range(quantity):
                 ACT_item: ACTItem = self.create_item(item)
                 ACT_items.append(ACT_item)
-                if remove_costumes:
-                    ACT_items.remove(costume_list)
 
         available_filler: List[str] = [filler for filler in items_to_create if items_to_create[filler] > 0 and item_table[filler].classification == ItemClassification.filler]
 

--- a/worlds/another_crab/__init__.py
+++ b/worlds/another_crab/__init__.py
@@ -60,6 +60,12 @@ class ACTWorld(World):
                 self.multiworld.get_location(lname.shelleport_skill, self.player).place_locked_item(shelleport)
             items_to_create[iname.shelleport] = 0
 
+        if self.options.fishinglinelocation:
+            fishing_line = self.create_item(iname.fishing_line)
+            if self.options.fishinglinelocation == "vanilla_location":
+                self.multiworld.get_location(lname.fishing_line, self.player).place_locked_item(fishing_line)
+            items_to_create[iname.fishing_line] = 0
+
         if self.options.removeCostumes:
             items_to_create[costume_list] = 0
 

--- a/worlds/another_crab/__init__.py
+++ b/worlds/another_crab/__init__.py
@@ -94,7 +94,7 @@ class ACTWorld(World):
             region.locations.append(location)
 
         self.multiworld.completion_condition[self.player] = \
-            lambda state: state.can_reach(spot = lname.royal_wave_reward, resolution_hint="Location", player = self.player)
+            lambda state: state.can_reach(spot = lname.home_shell, resolution_hint="Location", player = self.player)
 
     def set_rules(self) -> None:
         set_region_rules(self)

--- a/worlds/another_crab/items.py
+++ b/worlds/another_crab/items.py
@@ -19,7 +19,7 @@ class ACTItemData(NamedTuple):
 # a lot of quantities here will need to be adjusted later
 item_table: Dict[str, ACTItemData] = {
     # progression
-    #iname.fork: ACTItemData(ItemClassification.progression, 1, 1, "Progression"), 
+    iname.fork: ACTItemData(ItemClassification.progression, 1, 1, "Progression"), 
     #iname.heartkelp_pod: ACTItemData(ItemClassification.progression, 1, 2, "Progression"), #throwing this into the progression items because the average player will definitely need heals to beat the game.
     iname.fishing_line: ACTItemData(ItemClassification.progression, 1, 3, "Progression"),
     iname.pristine_pearl: ACTItemData(ItemClassification.progression, 1, 4, "Progression"),

--- a/worlds/another_crab/locations.py
+++ b/worlds/another_crab/locations.py
@@ -22,7 +22,7 @@ location_table: Dict[str, ACTLocationData] = {
     #Last used number: 617
 
     #lname.heartkelp_inital: ACTLocationData("Tide Pools", "Starting Items"),#950e628c-f657-48d4-b93b-f8717627f6b3-2_A-ShallowsTidePools
-    #lname.fork_pickup: ACTLocationData("Cave of Respite", 1,"Starting Items"),#73329d8e-7c96-4e82-9d3c-e57cc61b46b4-2_A-ShallowsTidePools
+    lname.fork_pickup: ACTLocationData(rname.starting_cave, 1, "Starting Items"),#73329d8e-7c96-4e82-9d3c-e57cc61b46b4-2_A-ShallowsTidePools
 
     # progression item locations
     lname.fishing_line: ACTLocationData(rname.slacktide_before, 2, "Fort Slacktide - Before Destruction"),

--- a/worlds/another_crab/locations.py
+++ b/worlds/another_crab/locations.py
@@ -19,14 +19,15 @@ location_table: Dict[str, ACTLocationData] = {
     # starting item locations (will probably just include heartkelp_initial and fork pickup because they are the items you pick up right at the beginning of the game)
 
 
-    #Last used number: 617
+    #Last used number: 618
 
     #lname.heartkelp_inital: ACTLocationData("Tide Pools", "Starting Items"),#950e628c-f657-48d4-b93b-f8717627f6b3-2_A-ShallowsTidePools
     lname.fork_pickup: ACTLocationData(rname.starting_cave, 1, "Starting Items"),#73329d8e-7c96-4e82-9d3c-e57cc61b46b4-2_A-ShallowsTidePools
 
     # progression item locations
-    lname.fishing_line: ACTLocationData(rname.slacktide_before, 2, "Fort Slacktide - Before Destruction"),
+    lname.fishing_line: ACTLocationData(rname.slacktide_before, 2, "Fort Slacktide"),
     #lname.pristine_pearl: ACTLocationData(rname.snail_cave, x, "Moon Snail's Cave"), #Redundant, overlaps with Platoon Pathfinder
+    lname.home_shell: ACTLocationData(rname.carcinia_ruins, 618, "Completion"),
 
     # boss locations
     lname.nephro: ACTLocationData(rname.central_shallows, 3, "Central Shallows"),

--- a/worlds/another_crab/names/item_names.py
+++ b/worlds/another_crab/names/item_names.py
@@ -131,6 +131,7 @@ spectral_tentacle = "Spectral Tentacle" # obtained from defeating the consortium
 urchin_toss = "Urchin Toss" #obtained from hugging the urchin in new carcinia
 
 # skills
+shelleport = "Shelleport"
 parry = "Parry"
 riposte = "Riposte"
 natural_defenses = "Natural Defenses"

--- a/worlds/another_crab/names/location_names.py
+++ b/worlds/another_crab/names/location_names.py
@@ -8,6 +8,7 @@ pristine_pearl = "Pristine Pearl" # reward for defeating platoon pathfinder
 map_piece_vale = "Map Piece - Flotsam Vale" # the map piece found in the mailbox in flotsam vale
 map_piece_heikea_arena = "Map Piece - Heikea" # the map piece in heikea's boss arena after defeating them
 map_piece_pagurus_defeat = "Map Piece - Pagurus" # the map piece obtained after defeating pagurus
+home_shell = "Home Shell" # kril's shell, completion location
 
 # currency item locations
 breadclaw_caveofrespite_ledge = "Breadclaw (Cave of Respite - Ledge)" # the first breadclaw the player has access to, in the cave of respite
@@ -172,7 +173,7 @@ chipclaw_flotsamvale_consortiumgrapple = "Chipclaw (Flotsam Vale - Past Consorti
 clothesclaw_flotsamvale_northfish = "Clothesclaw (Flotsam Vale - North Gunk Lake Fishing)"
 breadclaw_flotsamvale_westfish = "Breadclaw (Flotsam Vale - West Gunk Lake Fishing Near Shore)"
 clothesclaw_flotsamvale_northshorefish = "Clothesclaw (Flotsam Vale - North Gunk Lake Fihsing Near Shore)"
-clothesclaw_flotsamvale_southfish = "Clothesclaw (Flotsam Vale - Gunk Lake FIshing South of Sludge Steamroller)"
+clothesclaw_flotsamvale_southfish = "Clothesclaw (Flotsam Vale - Gunk Lake Fishing South of Sludge Steamroller)"
 hairclaw_flotsamvale_APfish = "Hairclaw (Flotsam Vale - Gunk Lake Fishing Outside Air Pocket Cave)"
 chipclaw_flotsamvale_consortiumfish = "Chipclaw (Flotsam Vale - Fishing Past Consortium)"
 paperclaw_flotsamvale_uppervale = "Paperclaw (Flotsam Vale - Near Upper Flotsam Vale)"

--- a/worlds/another_crab/names/region_names.py
+++ b/worlds/another_crab/names/region_names.py
@@ -18,7 +18,7 @@ unfathom = "The Unfathom" # where we are dumped after fighting roland and end up
 old_ocean = "The Old Ocean" # the ancient city where we fight camtscha
 drain_bottom = "Bottom of The Drain" # adding this and trash island even though there aren't any item checks - for if we want to do boss checks or all bosses goal
 trash_island = "Trash Island"
-carcinia_end = "Carcinia End" # adding this because it will probably needed if we want the win condition to be picking up kril's shell
+carcinia_ruins = "New Carcinia Ruins" # adding this because it will probably needed if we want the win condition to be picking up kril's shell
 
 # sub regions
 slacktide_before = "Fort Slacktide - Before Destruction" # slacktide before the player gets the pearl and slacktide goes crazy

--- a/worlds/another_crab/options.py
+++ b/worlds/another_crab/options.py
@@ -11,12 +11,20 @@ class ForkLocation(Choice):
     default = 0
 
 class ShelleportLocation(Choice):
-    """Choose where the Shelleport (fast travel) skill location will be
+    """Choose where the Shelleport (fast travel) skill location is set
     Available Options: shuffled, starting_items, vanilla_location"""
     display_name: str = "Shelleport Location"
     shuffled = 0
     starting_items = 1
     vanilla_location = 2
+    default = 0
+
+class FishingLineLocation(Choice):
+    """Choose where the Fishing Line (grapple) location is set
+    Available Options: shuffled, vanilla_location"""
+    display_name:str = "Fishing Line Location"
+    shuffled = 0
+    vanilla_location = 1
     default = 0
 
 class RemoveCostumes(Toggle):
@@ -40,6 +48,7 @@ class DeathLink(Toggle):
 class ACTGameOptions(PerGameCommonOptions):
     forkLocation: ForkLocation
     shelleportLocation: ShelleportLocation
+    fishinglinelocation: FishingLineLocation
     removeCostumes: RemoveCostumes
     microplasticMultiplier: MicroplasticMultiplier
     deathlink: DeathLink

--- a/worlds/another_crab/options.py
+++ b/worlds/another_crab/options.py
@@ -1,10 +1,23 @@
 from dataclasses import dataclass
 from Options import Toggle, Range, Choice, PerGameCommonOptions
 
-class RandomizeFork(Toggle):
-    """If enabled, the fork is added to the item pool. If disabled, the fork is left in its default location"""
+class ForkLocation(Choice):
+    """Choose where the Fork(weapon) location is set.
+    Available Options: vanilla_location, shuffled, shuffled_early"""
     display_name: str = "Randomize Fork"
-    default: bool = False
+    vanilla_location = 0
+    shuffled = 1
+    shuffled_early = 2
+    default = 0
+
+class ShelleportLocation(Choice):
+    """Choose where the Shelleport (fast travel) skill location will be
+    Available Options: shuffled, starting_items, vanilla_location"""
+    display_name: str = "Shelleport Location"
+    shuffled = 0
+    starting_items = 1
+    vanilla_location = 2
+    default = 0
 
 class RemoveCostumes(Toggle):
     """If enabled, removes costumes from the item pool"""
@@ -25,7 +38,8 @@ class DeathLink(Toggle):
 
 @dataclass
 class ACTGameOptions(PerGameCommonOptions):
-    randomizeFork: RandomizeFork
+    forkLocation: ForkLocation
+    shelleportLocation: ShelleportLocation
     removeCostumes: RemoveCostumes
     microplasticMultiplier: MicroplasticMultiplier
     deathlink: DeathLink

--- a/worlds/another_crab/rules.py
+++ b/worlds/another_crab/rules.py
@@ -459,3 +459,103 @@ def set_location_rules(world: "ACTWorld") -> None:
  # mantis punch
    set_rule(multiworld.get_location(lname.oldworldwhorl_grovevillage_topoda, player),
              lambda state: state.has(iname.mantis_punch, player))
+   
+# ---- Flotsam Vale ----
+
+ # spearfishing
+   set_rule(multiworld.get_location(lname.lamprey_flotsamvale_islandfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.mussel_flotsamvale_elevatedfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.barbedhook_flotsamvale_snailfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.siphonophoreplus_flotsamvale_waterfall, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.clothesclaw_flotsamvale_northfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.whelk_flotsamvale_westfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.breadclaw_flotsamvale_westfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.clothesclaw_flotsamvale_northshorefish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.clothesclaw_flotsamvale_southfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.barbedhook_flotsamvale_westfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.anemoneplus_flotsamvale_northwestfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.hairclaw_flotsamvale_gunkfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.breadclaw_flotsamvale_gunkfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.turtleshell_flotsamvale_gunkfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.clothesclaw_flotsamvale_gunkfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.barbedhook_flotsamvale_gunkfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.barbedhook_flotsamvale_sludgefish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.lilisopod_flotsamvale_gunkfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.hairclaw_flotsamvale_gunkfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.chipclaw_flotsamvale_gunkfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.rustynail_flotsamvale_gunkfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.barnacle_flotsamvale_gunkfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+ # grapple + spearfishing
+   set_rule(multiworld.get_location(lname.chipclaw_flotsamvale_consortiumfish, player),
+             lambda state: state.has_all(iname.spearfishing, iname.fishing_line, player))
+   
+# ---- Scuttleport ----
+
+ # grapple + eelectrocute (will add metal shell later)
+   set_rule(multiworld.get_location(lname.oldworldwhorl_scuttleport_eelectrocute, player),
+             lambda state: state.has_all(iname.fishing_line, iname.eelectrocute, player))
+   
+# ---- The Unfathom ----
+
+ # spearfishing
+   set_rule(multiworld.get_location(lname.salp_unfathom_glowstickfish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+   set_rule(multiworld.get_location(lname.barnacleplus_unfathom_pinbargefish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+# ---- Abyssal Plains ----
+
+ # spearfishing
+   set_rule(multiworld.get_location(lname.stapleclaw_plains_fish, player),
+             lambda state: state.has(iname.spearfishing, player))
+   
+# ---- The Old Ocean ----
+
+ # mantis punch
+   set_rule(multiworld.get_location(lname.whelkplusplus_oldocean_mantis, player),
+             lambda state: state.has(iname.mantis_punch, player))


### PR DESCRIPTION
Set up YAML options to force certain important progression item locations to be in their vanilla locations:
- Fork
- Shelleport
- Fishing Line

Also added necessary logic rules, a home shell location, and a new completion condition.