### PR TITLE
Added option for speedrun logic

### DIFF
--- a/worlds/another_crab/locations.py
+++ b/worlds/another_crab/locations.py
@@ -27,8 +27,8 @@ location_table: Dict[str, ACTLocationData] = {
     # progression item locations
     lname.fishing_line: ACTLocationData(rname.slacktide_before, 2, "Fort Slacktide - Before Destruction"),
     #lname.pristine_pearl: ACTLocationData(rname.snail_cave, x, "Moon Snail's Cave"), #Redundant, overlaps with Platoon Pathfinder
-    lname.map_piece_heikea_arena: ACTLocationData(rname.grove_main, 252, "Expired Grove Main"),
-    lname.map_piece_vale: ACTLocationData(rname.flotsam_vale, 396, "Flotsam Vale"),
+    lname.map_piece_heikea_arena: ACTLocationData(rname.grove_main, 252, "Expired Grove - Main"),
+    lname.map_piece_vale: ACTLocationData(rname.post_ceviche, 396, "Flotsam Vale - Post Ceviche Sisters"),
 
     # boss locations
     lname.nephro: ACTLocationData(rname.central_shallows, 3, "Central Shallows"),
@@ -36,11 +36,11 @@ location_table: Dict[str, ACTLocationData] = {
     lname.magista: ACTLocationData(rname.slacktide_after, 44, "Fort Slacktide - After Destruction"),
     lname.royal_shellsplitter: ACTLocationData(rname.central_shallows, 47, "Central Shallows"),
     lname.pagurus: ACTLocationData(rname.sands_between, 48, "Sands Between"),
-    lname.lichenthrope: ACTLocationData(rname.grove_main, 49, "Expired Grove Main"), #must fix region name and location group before re-adding
-    lname.carbonara_connoisseur: ACTLocationData(rname.grove_main, 50, "Expired Grove Main"),
-    lname.heikea: ACTLocationData(rname.grove_main, 51, "Expired Grove Main"),
-    lname.topoda: ACTLocationData(rname.grove_village, 52, "Expired Grove Village"),
-    lname.consortium: ACTLocationData(rname.flotsam_vale, 53, "Flotsam Vale"),
+    lname.lichenthrope: ACTLocationData(rname.grove_main, 49, "Expired Grove - Main"), #must fix region name and location group before re-adding
+    lname.carbonara_connoisseur: ACTLocationData(rname.grove_main, 50, "Expired Grove - Main"),
+    lname.heikea: ACTLocationData(rname.grove_main, 51, "Expired Grove - Main"),
+    lname.topoda: ACTLocationData(rname.grove_village, 52, "Expired Grove - Village"),
+    lname.consortium: ACTLocationData(rname.consortium_arena, 53, "Flotsam Vale - Consortium Arena"),
     lname.sludge_steamroller: ACTLocationData(rname.flotsam_vale, 54, "Flotsam Vale"),
     lname.ceviche_sisters: ACTLocationData(rname.flotsam_vale, 55, "Flotsam Vale"),
     lname.voltai: ACTLocationData(rname.scuttleport, 56, "Scuttleport"),
@@ -67,9 +67,9 @@ location_table: Dict[str, ACTLocationData] = {
     lname.breadclaw_shallows_cigarette: ACTLocationData(rname.slacktide_after, 10, "Fort Slacktide - After Destruction"), #d1ddf122-d283-4509-8bfa-bff8fa209f35-2_B-ShallowsBigSand
     lname.breadclaw_shallows_fortwall: ACTLocationData(rname.central_shallows, 11, "Central Shallows"), #20bede55-9eae-40a3-a80a-63ee5b52d0bf-2_B-ShallowsBigSand
     lname.breadclaw_shallows_wallpiece: ACTLocationData(rname.central_shallows, 12, "Central Shallows"), #5732b602-c599-41b5-bc5d-93e88277a4b7-2_B-ShallowsBigSand
-    lname.breadclaw_shallows_sandcastle: ACTLocationData(rname.central_shallows, 13, "Central Shallows"), #984eda06-d10e-4b2b-a5c4-389784ed18f6-2_B-ShallowsBigSand
-    lname.breadclaw_shallows_eastledge: ACTLocationData(rname.central_shallows, 14, "Central Shallows"), #51dbcbfd-4a82-4c22-b2ee-1a03deeca4cc-2_B-ShallowsBigSand
-    lname.hairclaw_shallows_turret: ACTLocationData(rname.central_shallows, 15, "Central Shallows"), #b2d21ade-41ab-47fc-960b-0beb6d07359d-2_B-ShallowsBigSand
+    lname.breadclaw_shallows_sandcastle: ACTLocationData(rname.central_shallows_grapple, 13, "Central Shallows - Items Behind Grapple"), #984eda06-d10e-4b2b-a5c4-389784ed18f6-2_B-ShallowsBigSand
+    lname.breadclaw_shallows_eastledge: ACTLocationData(rname.central_shallows_grapple, 14, "Central Shallows - Items Behind Grapple"), #51dbcbfd-4a82-4c22-b2ee-1a03deeca4cc-2_B-ShallowsBigSand
+    lname.hairclaw_shallows_turret: ACTLocationData(rname.central_shallows_grapple, 15, "Central Shallows - Items Behind Grapple"), #b2d21ade-41ab-47fc-960b-0beb6d07359d-2_B-ShallowsBigSand
     lname.chipclaw_shallows_sandcastle: ACTLocationData(rname.central_shallows, 16, "Central Shallows"), #12c6e5c5-eee1-4f9a-a3c4-68c2bd098a14-2_B-ShallowsBigSand
     #lname.clothesclaw_shallows_shellsplitter: ACTLocationData(rname.central_shallows, 17, "Central Shallows"), #AUTO NEEDS TO DO BOSS SCRIPT
     lname.clothesclaw_shallows_southwestfort: ACTLocationData(rname.central_shallows, 45, "Central Shallows"), #e13e2c76-a638-4023-aa84-f6f29fd7bf65-2_B-ShallowsBigSand
@@ -89,7 +89,7 @@ location_table: Dict[str, ACTLocationData] = {
     lname.breadclaw_slacktide_roofhiddenfish: ACTLocationData(rname.slacktide_after, 131, "Fort Slacktide - After Destruction"), #59e2ec5a-b650-43fa-879d-3af1569fb640-2_B-ShallowsBigSand
 
     lname.chipclaw_reefsedge_brokenbridge: ACTLocationData(rname.reefs_edge, 63, "Reef's Edge"), #e9bf56b8-1362-42a9-87a2-00bed3a6f5d2-2_A-NCTradeRoute
-    lname.breadclaw_reefsedge_thimblecrab: ACTLocationData(rname.reefs_edge, 67, "Reef's Edge"), #1f5a8d6b-10ab-4e4e-b240-284e2ec2c77a-2_A-NCTradeRoute
+    lname.breadclaw_reefsedge_thimblecrab: ACTLocationData(rname.reefs_edge_grapple, 67, "Reef's Edge - Items Behind Grapple"), #1f5a8d6b-10ab-4e4e-b240-284e2ec2c77a-2_A-NCTradeRoute
     lname.hairclaw_reefsedge_sign: ACTLocationData(rname.reefs_edge, 71, "Reef's Edge"), #b478df52-084c-4c14-8a55-215fdbaeaffe-2_A-NCTradeRoute
 
     lname.breadclaw_newcarcinia_entrance: ACTLocationData(rname.new_carcinia, 74, "New Carcinia"), #fb5e2e88-b498-4af4-b7a6-4f176eb4016c-2_B-NCCity
@@ -113,7 +113,7 @@ location_table: Dict[str, ACTLocationData] = {
     lname.hairclaw_sandsbetween_northchains: ACTLocationData(rname.sands_between, 137, "The Sands Between"), #7e4ef7d0-214a-4358-a0c3-866a869d71e0-2_A-OOGroveRadius
     lname.clothesclaw_sandsbetween_coolerpitfall: ACTLocationData(rname.sands_between, 138, "The Sands Between"), #9faef117-fd92-47cb-b4d8-cc2a07404a69-2_A-OOGroveRadius
     lname.hairclaw_sandsbetween_southgrovepit: ACTLocationData(rname.sands_between, 139, "The Sands Between"), #305be10e-d5a7-42e6-88f1-2cebdd524bbb-2_A-OOGroveRadius
-    lname.paperclaw_sandsbetween_southeelshortcut: ACTLocationData(rname.sands_between, 147, "The Sands Between"), #0e2d558b-26a7-4213-be83-77355fe06128-2_A-OOGroveRadius
+    lname.paperclaw_sandsbetween_southeelshortcut: ACTLocationData(rname.southern_town_ridge, 147, "The Sands Between - Southern Town Ridge"), #0e2d558b-26a7-4213-be83-77355fe06128-2_A-OOGroveRadius
     lname.hairclaw_sandsbetween_southeel: ACTLocationData(rname.sands_between, 150, "The Sands Between"), #5c8133eb-ddb3-4b24-9849-f4d3f03491e0-2_A-OOGroveRadius
     lname.paperclaw_sandsbetween_trashanchor: ACTLocationData(rname.sands_between, 155, "The Sands Between"), #98e4d994-92c4-4b3b-82b7-f460a49d604b-2_A-OOGroveRadius
     lname.hairclaw_sandsbetween_anchorfish: ACTLocationData(rname.sands_between, 156, "The Sands Between"), #cab91803-4006-456d-95c7-6ec17d90c26a-2_A-OOGroveRadius
@@ -122,7 +122,7 @@ location_table: Dict[str, ACTLocationData] = {
     lname.clothesclaw_sandsbetween_anchorcentralfish: ACTLocationData(rname.sands_between, 160, "The Sands Between"), #628bf319-c5f3-448b-8ec0-71a173246a09-2_A-OOGroveRadius
     lname.breadclaw_sandsbetween_nailfish: ACTLocationData(rname.sands_between, 162, "The Sands Between"), #98c3bf98-c4bd-4c67-8678-0464e7095970-2_A-OOGroveRadius
     lname.breadclaw_sandsbetween_palletfish: ACTLocationData(rname.sands_between, 163, "The Sands Between"), #69ac316d-8d42-48a4-8d55-4ec4d6429c7c-2_A-OOGroveRadius
-    lname.hairclaw_sandsbetween_southeelfish: ACTLocationData(rname.sands_between, 164, "The Sands Between"), #38edc1a4-dea8-4000-8683-6cda7f6ba3bc-2_A-OOGroveRadius
+    lname.hairclaw_sandsbetween_southeelfish: ACTLocationData(rname.southern_town_ridge, 164, "The Sands Between - Southern Town Ridge"), #38edc1a4-dea8-4000-8683-6cda7f6ba3bc-2_A-OOGroveRadius
     lname.chipclaw_sandsbetween_anchoreelhiddenfish: ACTLocationData(rname.sands_between, 165, "The Sands Between"), #01999bed-4813-4fe3-ab9b-5ed19cce90f1-2_A-OOGroveRadius
 
     lname.stapleclaw_postpag_litter: ACTLocationData(rname.post_pag, 170, "The Sands Between - Post Pagurus"), #e872d437-5bdb-4e70-820a-030bc21d66d5-2_A-OOGroveRadius
@@ -140,48 +140,48 @@ location_table: Dict[str, ACTLocationData] = {
     lname.clothesclaw_ridge_overlookfish: ACTLocationData(rname.secluded_ridge, 206, "The Sands Between - Secluded Ridge"), #4f737f9e-a952-490c-b54d-1f74735af9cc-2_A-OOGroveRadius
     lname.chipclaw_ridge_southfish: ACTLocationData(rname.secluded_ridge, 207, "The Sands Between - Secluded Ridge"), #82043889-30eb-45f4-8f87-45dd2f5d69ed-2_A-OOGroveRadius
 
-    lname.stapleclaw_trashbin_eelfish: ACTLocationData(rname.secluded_ridge, 209, "The Sands Between - Trashbin Plateau"), #190034bb-c13e-42ec-bac4-037cc828fde3-2_A-OOGroveRadius
+    lname.stapleclaw_trashbin_eelfish: ACTLocationData(rname.trashbin_plateau, 209, "The Sands Between - Trashbin Plateau"), #190034bb-c13e-42ec-bac4-037cc828fde3-2_A-OOGroveRadius
 
-    lname.breadclaw_grovemain_takeout: ACTLocationData(rname.grove_main, 219, "Expired Grove Main"), #4933d4b0-a56a-4472-b9a6-4469fd335fa4-2_A-GroveForestLow
-    lname.breadclaw_grovemain_tiretop: ACTLocationData(rname.grove_main, 224, "Expired Grove Main"), #da04ed8f-2d99-48f9-8412-67748d983d2b-2_A-GroveForestLow
-    lname.chipclaw_grovemain_plastic: ACTLocationData(rname.grove_main, 225, "Expired Grove Main"), #902c2deb-1b51-4226-9fd0-1c76bea668c3-2_A-GroveForestLow
-    lname.clothesclaw_grovemain_choccymilk: ACTLocationData(rname.grove_main, 226, "Expired Grove Main"), #e38ef2da-daaf-4312-bf7f-2e0a97d3d67b-2_A-GroveForestLow
-    lname.breadclaw_grovemain_insidetire: ACTLocationData(rname.grove_main, 227, "Expired Grove Main"), #def84515-cfc0-4124-a1e1-81f6953b0c06-2_A-GroveForestLow
-    lname.chipclaw_grovemain_sniper: ACTLocationData(rname.grove_main, 245, "Expired Grove Main"), #070b84a6-7a8b-4d88-8216-f55882856713-2_A-GroveForestLow
-    lname.hairclaw_grovemain_milkurchins: ACTLocationData(rname.grove_main, 246, "Expired Grove Main"), #e78f03e8-2827-45d7-8cfa-cbaa0f17cd3d-2_A-GroveForestLow
-    lname.breadclaw_grovemain_smallhall: ACTLocationData(rname.grove_main, 231, "Expired Grove Main"), #be378f83-9ec2-4a3b-85b2-9a7499e6d693-2_A-GroveForestLow
-    lname.chipclaw_grovemain_apples: ACTLocationData(rname.grove_main, 232, "Expired Grove Main"), #faa3c9ce-87c7-4f6d-b07e-be334c3bc447-2_A-GroveForestLow
-    lname.chipclaw_grovemain_sodacans: ACTLocationData(rname.grove_main, 233, "Expired Grove Main"), #25737275-a222-4a6e-af6b-0c66c197cab7-2_A-GroveForestLow
-    lname.hairclaw_grovemain_moonshine: ACTLocationData(rname.grove_main, 234, "Expired Grove Main"), #fd557b69-ddba-4b14-bd80-f0cb0d786203-2_A-GroveForestLow
-    lname.chipclaw_grovemain_circlerock: ACTLocationData(rname.grove_main, 238, "Expired Grove Main"), #1b74ef4f-528c-484b-9a5f-abbb3434f133-2_A-GroveForestLow
-    lname.clothesclaw_grovemain_alcove: ACTLocationData(rname.grove_main, 239, "Expired Grove Main"), #f99a120b-43c2-4e65-91fd-71cbfbf3e8f7-2_A-GroveForestLow
-    lname.hairclaw_grovemain_sniper: ACTLocationData(rname.grove_main, 240, "Expired Grove Main"), #8f4a1f33-e567-4c84-b34b-739353b3ba08-2_A-GroveForestLow
-    lname.breadclaw_grovemain_amongus: ACTLocationData(rname.grove_main, 243, "Expired Grove Main"), #c859129f-cc29-4624-a161-fdeffa00d0ca-2_B-GroveForestHigh
-    lname.breadclaw_grovemain_oildrum: ACTLocationData(rname.grove_main, 244, "Expired Grove Main"), #b85cb09c-f1d7-4396-85cb-fde4dc845acd-2_B-GroveForestHigh
-    lname.breadclaw_grovemain_oilgrapple: ACTLocationData(rname.grove_main, 249, "Expired Grove Main"), #bc18b92b-a6c6-420c-9095-e15c34c2f921-2_B-GroveForestHigh
-    lname.clothesclaw_grovemain_mantisfish: ACTLocationData(rname.grove_main, 256, "Expired Grove Main"), #048736b5-59c1-4dd2-b36a-e11b6bd9304f-2_A-GroveForestLow
-    lname.hairclaw_grovemain_fishing: ACTLocationData(rname.grove_main, 257, "Expired Grove Main"), #23907bde-1820-4c4d-9c59-aab72c64139a-2_A-GroveForestLow
-    lname.clothesclaw_grovemain_riverfish: ACTLocationData(rname.grove_main, 258, "Expired Grove Main"), #ebad553d-fbff-441e-8c1d-0ccc65fe81ae-2_A-GroveForestLow
+    lname.breadclaw_grovemain_takeout: ACTLocationData(rname.grove_main, 219, "Expired Grove - Main"), #4933d4b0-a56a-4472-b9a6-4469fd335fa4-2_A-GroveForestLow
+    lname.breadclaw_grovemain_tiretop: ACTLocationData(rname.grove_main, 224, "Expired Grove - Main"), #da04ed8f-2d99-48f9-8412-67748d983d2b-2_A-GroveForestLow
+    lname.chipclaw_grovemain_plastic: ACTLocationData(rname.grove_main, 225, "Expired Grove - Main"), #902c2deb-1b51-4226-9fd0-1c76bea668c3-2_A-GroveForestLow
+    lname.clothesclaw_grovemain_choccymilk: ACTLocationData(rname.grove_main, 226, "Expired Grove - Main"), #e38ef2da-daaf-4312-bf7f-2e0a97d3d67b-2_A-GroveForestLow
+    lname.breadclaw_grovemain_insidetire: ACTLocationData(rname.grove_main, 227, "Expired Grove - Main"), #def84515-cfc0-4124-a1e1-81f6953b0c06-2_A-GroveForestLow
+    lname.chipclaw_grovemain_sniper: ACTLocationData(rname.grove_main, 245, "Expired Grove - Main"), #070b84a6-7a8b-4d88-8216-f55882856713-2_A-GroveForestLow
+    lname.hairclaw_grovemain_milkurchins: ACTLocationData(rname.grove_main, 246, "Expired Grove - Main"), #e78f03e8-2827-45d7-8cfa-cbaa0f17cd3d-2_A-GroveForestLow
+    lname.breadclaw_grovemain_smallhall: ACTLocationData(rname.grove_main, 231, "Expired Grove - Main"), #be378f83-9ec2-4a3b-85b2-9a7499e6d693-2_A-GroveForestLow
+    lname.chipclaw_grovemain_apples: ACTLocationData(rname.grove_main, 232, "Expired Grove - Main"), #faa3c9ce-87c7-4f6d-b07e-be334c3bc447-2_A-GroveForestLow
+    lname.chipclaw_grovemain_sodacans: ACTLocationData(rname.grove_main, 233, "Expired Grove - Main"), #25737275-a222-4a6e-af6b-0c66c197cab7-2_A-GroveForestLow
+    lname.hairclaw_grovemain_moonshine: ACTLocationData(rname.grove_main, 234, "Expired Grove - Main"), #fd557b69-ddba-4b14-bd80-f0cb0d786203-2_A-GroveForestLow
+    lname.chipclaw_grovemain_circlerock: ACTLocationData(rname.grove_main, 238, "Expired Grove - Main"), #1b74ef4f-528c-484b-9a5f-abbb3434f133-2_A-GroveForestLow
+    lname.clothesclaw_grovemain_alcove: ACTLocationData(rname.grove_main, 239, "Expired Grove - Main"), #f99a120b-43c2-4e65-91fd-71cbfbf3e8f7-2_A-GroveForestLow
+    lname.hairclaw_grovemain_sniper: ACTLocationData(rname.grove_raised_platforms, 240, "Expired Grove - Raised Platforms"), #8f4a1f33-e567-4c84-b34b-739353b3ba08-2_A-GroveForestLow
+    lname.breadclaw_grovemain_amongus: ACTLocationData(rname.grove_main, 243, "Expired Grove - Main"), #c859129f-cc29-4624-a161-fdeffa00d0ca-2_B-GroveForestHigh
+    lname.breadclaw_grovemain_oildrum: ACTLocationData(rname.grove_main, 244, "Expired Grove - Main"), #b85cb09c-f1d7-4396-85cb-fde4dc845acd-2_B-GroveForestHigh
+    lname.breadclaw_grovemain_oilgrapple: ACTLocationData(rname.grove_main, 249, "Expired Grove - Main"), #bc18b92b-a6c6-420c-9095-e15c34c2f921-2_B-GroveForestHigh
+    lname.clothesclaw_grovemain_mantisfish: ACTLocationData(rname.grove_main, 256, "Expired Grove - Main"), #048736b5-59c1-4dd2-b36a-e11b6bd9304f-2_A-GroveForestLow
+    lname.hairclaw_grovemain_fishing: ACTLocationData(rname.grove_main, 257, "Expired Grove - Main"), #23907bde-1820-4c4d-9c59-aab72c64139a-2_A-GroveForestLow
+    lname.clothesclaw_grovemain_riverfish: ACTLocationData(rname.grove_main, 258, "Expired Grove - Main"), #ebad553d-fbff-441e-8c1d-0ccc65fe81ae-2_A-GroveForestLow
 
-    lname.breadclaw_grovevillage_oildrum: ACTLocationData(rname.grove_village, 268, "Expired Grove Village"), #66a4a627-ad3a-45d6-aaf1-1e505dac0495-2_B-GroveForestHigh
-    lname.breadclaw_grovevillage_bottle1: ACTLocationData(rname.grove_village, 269, "Expired Grove Village"), #a6e719fc-65b0-4c3a-830e-43065a819c7d-2_B-GroveForestHigh
-    lname.breadclaw_grovevillage_bottle2: ACTLocationData(rname.grove_village, 270, "Expired Grove Village"), #507a5ca4-3de6-4d85-ba51-04c1e42c891e-2_B-GroveForestHigh
-    lname.chipclaw_grovevillage_netorbs: ACTLocationData(rname.grove_village, 253, "Expired Grove Village"), #df0386e0-99ee-478a-873d-b40e973fc16b-2_D-Caves
-    lname.hairclaw_grovevillage_river: ACTLocationData(rname.grove_village, 272, "Expired Grove Village"), #ec08fee3-e62f-45ee-9fbe-9101522d4f30-2_B-GroveForestHigh
-    lname.chipclaw_grovevillage_NWcarton: ACTLocationData(rname.grove_village, 276, "Expired Grove Village"), #84c9cc27-0876-4e4d-a9e2-c28f06abdfc3-2_C-Village
-    lname.chipclaw_grovevillage_SEcarton: ACTLocationData(rname.grove_village, 281, "Expired Grove Village"), #c83c8f42-474a-4dd4-bbae-99df2ad1681a-2_C-Village
-    lname.chipclaw_grovevillage_NEcarton: ACTLocationData(rname.grove_village, 283, "Expired Grove Village"), #1cd62e82-14b4-4a8a-8dc1-7e8f0ff9b11b-2_C-Village
-    lname.breadclaw_grovevillage_shortcut: ACTLocationData(rname.grove_village, 289, "Expired Grove Village"), #ff8f29f4-2859-4ff7-857f-54e0a9c185fa-2_D-Caves
-    lname.chipclaw_grovevillage_cave: ACTLocationData(rname.grove_village, 291, "Expired Grove Village"), #6dbab2ee-2440-4b3d-944e-688f11a88199-2_D-Caves
-    lname.hairclaw_grovevillage_entrance: ACTLocationData(rname.grove_village, 292, "Expired Grove Village"), #7434f4f5-8e47-40f0-b3a3-507ada236333-2_D-Caves
-    lname.breadclaw_grovevillage_Scarton: ACTLocationData(rname.grove_village, 293, "Expired Grove Village"), #b1b6be9e-1973-4562-8e96-43adf0d8fcd5-2_C-Village
-    lname.breadclaw_grovevillage_entrance: ACTLocationData(rname.grove_village, 294, "Expired Grove Village"), #dc39a6c7-45be-4e9a-9ac2-4da3094395dd-2_C-Village
-    lname.hairclaw_grovevillage_NEcarton: ACTLocationData(rname.grove_village, 297, "Expired Grove Village"), #3eee4944-4b1e-4680-92de-0ee564c91330-2_C-Village
-    lname.clothesclaw_grovevillage_upsidedown: ACTLocationData(rname.grove_village, 299, "Expired Grove Village"), #8e368d78-572e-4fed-8607-2fb4c35b23e8-2_C-Village
-    lname.clothesclaw_grovevillage_dock: ACTLocationData(rname.grove_village, 311, "Expired Grove Village"), #2a160afc-7439-4e22-9f2b-62fa152f6626-2_C-Village
-    lname.hairclaw_grovevillage_dock: ACTLocationData(rname.grove_village, 312, "Expired Grove Village"), #08e5033e-a401-4e90-a1a5-7e9e76ed72a5-2_C-Village
-    lname.clothesclaw_grovevillage_hidden: ACTLocationData(rname.grove_village, 314, "Expired Grove Village"), #3bd305d9-8d6b-43c4-99c7-1f2be904de06-2_E-Cliffs
-    lname.carclaw_grovevillage_topoda: ACTLocationData(rname.grove_village, 315, "Expired Grove Village"), #2601baa3-999e-443b-ae33-ea619346413b-2_E-Cliffs
+    lname.breadclaw_grovevillage_oildrum: ACTLocationData(rname.grove_village, 268, "Expired Grove - Village"), #66a4a627-ad3a-45d6-aaf1-1e505dac0495-2_B-GroveForestHigh
+    lname.breadclaw_grovevillage_bottle1: ACTLocationData(rname.grove_village, 269, "Expired Grove - Village"), #a6e719fc-65b0-4c3a-830e-43065a819c7d-2_B-GroveForestHigh
+    lname.breadclaw_grovevillage_bottle2: ACTLocationData(rname.grove_village, 270, "Expired Grove - Village"), #507a5ca4-3de6-4d85-ba51-04c1e42c891e-2_B-GroveForestHigh
+    lname.chipclaw_grovevillage_netorbs: ACTLocationData(rname.grove_village, 253, "Expired Grove - Village"), #df0386e0-99ee-478a-873d-b40e973fc16b-2_D-Caves
+    lname.hairclaw_grovevillage_river: ACTLocationData(rname.grove_village, 272, "Expired Grove - Village"), #ec08fee3-e62f-45ee-9fbe-9101522d4f30-2_B-GroveForestHigh
+    lname.chipclaw_grovevillage_NWcarton: ACTLocationData(rname.grove_village, 276, "Expired Grove - Village"), #84c9cc27-0876-4e4d-a9e2-c28f06abdfc3-2_C-Village
+    lname.chipclaw_grovevillage_SEcarton: ACTLocationData(rname.grove_village, 281, "Expired Grove - Village"), #c83c8f42-474a-4dd4-bbae-99df2ad1681a-2_C-Village
+    lname.chipclaw_grovevillage_NEcarton: ACTLocationData(rname.grove_village, 283, "Expired Grove - Village"), #1cd62e82-14b4-4a8a-8dc1-7e8f0ff9b11b-2_C-Village
+    lname.breadclaw_grovevillage_shortcut: ACTLocationData(rname.grove_village, 289, "Expired Grove - Village"), #ff8f29f4-2859-4ff7-857f-54e0a9c185fa-2_D-Caves
+    lname.chipclaw_grovevillage_cave: ACTLocationData(rname.grove_village, 291, "Expired Grove - Village"), #6dbab2ee-2440-4b3d-944e-688f11a88199-2_D-Caves
+    lname.hairclaw_grovevillage_entrance: ACTLocationData(rname.grove_village, 292, "Expired Grove - Village"), #7434f4f5-8e47-40f0-b3a3-507ada236333-2_D-Caves
+    lname.breadclaw_grovevillage_Scarton: ACTLocationData(rname.grove_village, 293, "Expired Grove - Village"), #b1b6be9e-1973-4562-8e96-43adf0d8fcd5-2_C-Village
+    lname.breadclaw_grovevillage_entrance: ACTLocationData(rname.grove_village, 294, "Expired Grove - Village"), #dc39a6c7-45be-4e9a-9ac2-4da3094395dd-2_C-Village
+    lname.hairclaw_grovevillage_NEcarton: ACTLocationData(rname.grove_village, 297, "Expired Grove - Village"), #3eee4944-4b1e-4680-92de-0ee564c91330-2_C-Village
+    lname.clothesclaw_grovevillage_upsidedown: ACTLocationData(rname.grove_village, 299, "Expired Grove - Village"), #8e368d78-572e-4fed-8607-2fb4c35b23e8-2_C-Village
+    lname.clothesclaw_grovevillage_dock: ACTLocationData(rname.grove_village, 311, "Expired Grove - Village"), #2a160afc-7439-4e22-9f2b-62fa152f6626-2_C-Village
+    lname.hairclaw_grovevillage_dock: ACTLocationData(rname.grove_village, 312, "Expired Grove - Village"), #08e5033e-a401-4e90-a1a5-7e9e76ed72a5-2_C-Village
+    lname.clothesclaw_grovevillage_hidden: ACTLocationData(rname.grove_village, 314, "Expired Grove - Village"), #3bd305d9-8d6b-43c4-99c7-1f2be904de06-2_E-Cliffs
+    lname.carclaw_grovevillage_topoda: ACTLocationData(rname.grove_village, 315, "Expired Grove - Village"), #2601baa3-999e-443b-ae33-ea619346413b-2_E-Cliffs
 
     lname.chipclaw_flotsamvale_sheetmetal: ACTLocationData(rname.flotsam_vale, 340, "Flotsam Vale"),#2f65dc9d-5ea6-4480-b8fb-c9a9bcd779d6-2_B-LowSwamp
     lname.chipclaw_flotsamvale_beach: ACTLocationData(rname.flotsam_vale, 341, "Flotsam Vale"), #39365f04-a3c8-44e8-a398-bff99a84d2a7-2_B-LowSwamp
@@ -210,15 +210,15 @@ location_table: Dict[str, ACTLocationData] = {
     lname.hairclaw_flotsamvale_APabove2: ACTLocationData(rname.flotsam_vale, 394, "Flotsam Vale"), #2112465c-60b4-423a-8bb7-301a64aec108-2_A-HighSwamp
     lname.paperclaw_flotsamvale_shippingdock: ACTLocationData(rname.flotsam_vale, 400, "Flotsam Vale"), #771c0772-2715-42c1-90b1-e033997895d1-2_A-HighSwamp
     lname.hairclaw_flotsamvale_trashpile: ACTLocationData(rname.flotsam_vale, 401, "Flotsam Vale"), #3ef191f5-0296-4760-b9ef-8d2fa99ac914-2_A-HighSwamp
-    lname.clothesclaw_flotsamvale_consortium: ACTLocationData(rname.flotsam_vale, 404, "Flotsam Vale"), #9d34e68d-94a3-417c-a919-ddaf13b1c257-2_B-LowSwamp
+    lname.clothesclaw_flotsamvale_consortium: ACTLocationData(rname.consortium_arena, 404, "Flotsam Vale - Consortium Arena"), #9d34e68d-94a3-417c-a919-ddaf13b1c257-2_B-LowSwamp
     lname.paperclaw_flotsamvale_billboard: ACTLocationData(rname.flotsam_vale, 406, "Flotsam Vale"), #92744ee7-94a9-4abf-a3e2-93d91b82d02f-2_A-HighSwamp
-    lname.chipclaw_flotsamvale_consortiumgrapple: ACTLocationData(rname.flotsam_vale, 409, "Flotsam Vale"), #ececfd87-e180-425f-9aaa-3a569bbfb5ea-2_B-LowSwamp
+    lname.chipclaw_flotsamvale_consortiumgrapple: ACTLocationData(rname.consortium_arena, 409, "Flotsam Vale - Consortium Arena"), #ececfd87-e180-425f-9aaa-3a569bbfb5ea-2_B-LowSwamp
     lname.clothesclaw_flotsamvale_northfish: ACTLocationData(rname.flotsam_vale, 415, "Flotsam Vale"), #98e712ca-a037-4b20-81b6-e18d8221581a-2_B-LowSwamp
     lname.breadclaw_flotsamvale_westfish: ACTLocationData(rname.flotsam_vale, 417, "Flotsam Vale"), #2cd9c105-6c9e-4225-92d0-68a3d9488a4c-2_B-LowSwamp
     lname.clothesclaw_flotsamvale_northshorefish: ACTLocationData(rname.flotsam_vale, 418, "Flotsam Vale"), #d4dcf093-3098-419f-83c6-72a4d0626cc3-2_B-LowSwamp
     lname.clothesclaw_flotsamvale_southfish: ACTLocationData(rname.flotsam_vale, 419, "Flotsam Vale"), #4cce8eec-cc51-43c3-b629-768b62a16314-2_A-HighSwamp
     lname.hairclaw_flotsamvale_APfish: ACTLocationData(rname.flotsam_vale, 422, "Flotsam Vale"), #df4a99c6-a331-4b68-8ab3-33840fa40519-2_A-HighSwamp
-    lname.chipclaw_flotsamvale_consortiumfish: ACTLocationData(rname.flotsam_vale, 423, "Flotsam Vale"), #2fd08de6-99fb-45f8-95e3-d32832180314-2_B-LowSwamp
+    lname.chipclaw_flotsamvale_consortiumfish: ACTLocationData(rname.consortium_arena, 423, "Flotsam Vale - Consortium Arena"), #2fd08de6-99fb-45f8-95e3-d32832180314-2_B-LowSwamp
     lname.paperclaw_flotsamvale_uppervale: ACTLocationData(rname.flotsam_vale, 606, "Flotsam Vale"), #99e59ba9-3c41-4133-bf7e-d09bc1957f04-2_A-HighSwamp
     lname.breadclaw_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 608, "Flotsam Vale"), #669e8494-68f1-4de8-8814-6b41a0a69d18-2_A-HighSwamp
     lname.clothesclaw_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 610, "Flotsam Vale"), #b4a9c83a-b0c6-4606-a785-16f4ff33d66e-2_A-HighSwamp
@@ -323,30 +323,30 @@ location_table: Dict[str, ACTLocationData] = {
     lname.tacklepouch_sandsbetween_cooler: ACTLocationData(rname.sands_between, 97, "The Sands Between"), #550401bf-30db-4deb-8267-ac73d522236d-2_A-OOGroveRadius
     lname.bloodstar_sandsbetween_southwestcentral: ACTLocationData(rname.sands_between, 133, "The Sands Between"), #956ad9a9-5b43-4f18-a7d9-f67f21c50137-2_A-OOGroveRadius
     lname.oldworldwhorl_sandsbetween_mantispitfall: ACTLocationData(rname.sands_between, 143, "The Sands Between"), #8c7fdc4d-423b-4456-8869-56387a4d7665-2_A-OOGroveRadius
-    lname.stainlessrelic_sandsbetween_eelectrocute: ACTLocationData(rname.sands_between, 145, "The Sands Between"), #83daf909-77d3-4302-858b-6e92fe54fe74-2_A-OOGroveRadius
+    lname.stainlessrelic_sandsbetween_eelectrocute: ACTLocationData(rname.southern_town_ridge, 145, "The Sands Between - Southern Town Ridge"), #83daf909-77d3-4302-858b-6e92fe54fe74-2_A-OOGroveRadius
     lname.tacklepouch_sandsbetween_eelnorthchain: ACTLocationData(rname.sands_between, 146, "The Sands Between"), #699b7323-fe71-4bfe-864f-cdd0c9186bbd-2_A-OOGroveRadius
-    lname.kelpsprout_sandsbetween_southeelside: ACTLocationData(rname.sands_between, 151, "The Sands Between"), #a7c60b04-8f1b-4833-a6f4-d472e79748c5-2_A-OOGroveRadius
+    lname.kelpsprout_sandsbetween_southeelside: ACTLocationData(rname.southern_town_ridge, 151, "The Sands Between - Southern Town Ridge"), #a7c60b04-8f1b-4833-a6f4-d472e79748c5-2_A-OOGroveRadius
 
     lname.bloodstar_postpag_anchorswarm: ACTLocationData(rname.post_pag, 169, "The Sands Between - Post Pagurus"), #29e54e45-4248-4a3d-96bf-ddf5cf6046c7-2_A-OOGroveRadius
 
     lname.stainlessrelic_ridge_overlook: ACTLocationData(rname.secluded_ridge, 186, "The Sands Between - Secluded Ridge"), #c56be461-0e5c-406e-8af0-83021f2f2fb6-2_A-OOGroveRadius
-    lname.kelpsprout_ridge_eelend: ACTLocationData(rname.secluded_ridge, 188, "The Sands Between - Secluded Ridge"), #d56339c0-fc26-4f53-a289-2c00b6f7ab38-2_A-OOGroveRadius
+    lname.kelpsprout_ridge_eelend: ACTLocationData(rname.secluded_ridge_eel, 188, "The Sands Between - Secluded Ridge Eelectrocute"), #d56339c0-fc26-4f53-a289-2c00b6f7ab38-2_A-OOGroveRadius
     lname.oldworldwhorl_ridge_ncliff: ACTLocationData(rname.secluded_ridge, 190, "The Sands Between - Secluded Ridge"), #8e381b9e-ab7a-44ad-81c3-19157c97e0c6-2_A-OOGroveRadius
-    lname.oldworldwhorl_ridge_eelclam: ACTLocationData(rname.secluded_ridge, 205, "The Sands Between - Secluded Ridge"), #80e66e11-8e9a-4896-9db1-f8cd4a25fefc-2_A-OOGroveRadius
+    lname.oldworldwhorl_ridge_eelclam: ACTLocationData(rname.secluded_ridge_eel, 205, "The Sands Between - Secluded Ridge Eelectrocute"), #80e66e11-8e9a-4896-9db1-f8cd4a25fefc-2_A-OOGroveRadius
 
-    lname.oldworldwhorl_grovemain_southclam: ACTLocationData(rname.grove_main, 217, "Expired Grove Main"), #09b60c18-2172-41bb-9588-a3e764559b15-2_B-GroveForestHigh
-    lname.bloodstar_grovemain_waterfall: ACTLocationData(rname.grove_main, 229, "Expired Grove Main"), #f1d3eafe-c252-4768-abcd-7f459e734d35-2_A-GroveForestLow
-    lname.kelpsprout_grovemain_carts: ACTLocationData(rname.grove_main, 261, "Expired Grove Main"), #7069eee2-4c77-4a80-a276-1131e6cfe4b8-2_A-GroveForestLow
+    lname.oldworldwhorl_grovemain_southclam: ACTLocationData(rname.grove_main, 217, "Expired Grove - Main"), #09b60c18-2172-41bb-9588-a3e764559b15-2_B-GroveForestHigh
+    lname.bloodstar_grovemain_waterfall: ACTLocationData(rname.grove_main, 229, "Expired Grove - Main"), #f1d3eafe-c252-4768-abcd-7f459e734d35-2_A-GroveForestLow
+    lname.kelpsprout_grovemain_carts: ACTLocationData(rname.grove_main, 261, "Expired Grove - Main"), #7069eee2-4c77-4a80-a276-1131e6cfe4b8-2_A-GroveForestLow
 
-    lname.bloodstar_grovevillage_carton: ACTLocationData(rname.grove_village, 295, "Expired Grove Village"), #e9f1284d-a5cf-441e-a358-8cabf5e3a7b1-2_C-Village
-    lname.tacklepouch_grovevillage_clam: ACTLocationData(rname.grove_village, 298, "Expired Grove Village"), #c69ffc64-04af-44d1-b470-a867c5f06199-2_D-Caves
-    lname.stainlessrelic_grovevillage_clam: ACTLocationData(rname.grove_village, 307, "Expired Grove Village"), #269526ef-6bb0-42cf-a93d-e2cac970e424-2_E-Cliffs
-    lname.oldworldwhorl_grovevillage_topoda: ACTLocationData(rname.grove_village, 316, "Expired Grove Village"), #8b9b3b77-b95f-46a2-adfd-ca962e8f0cef-2_E-Cliffs
+    lname.bloodstar_grovevillage_carton: ACTLocationData(rname.grove_village, 295, "Expired Grove - Village"), #e9f1284d-a5cf-441e-a358-8cabf5e3a7b1-2_C-Village
+    lname.tacklepouch_grovevillage_clam: ACTLocationData(rname.grove_village, 298, "Expired Grove - Village"), #c69ffc64-04af-44d1-b470-a867c5f06199-2_D-Caves
+    lname.stainlessrelic_grovevillage_clam: ACTLocationData(rname.grove_village, 307, "Expired Grove - Village"), #269526ef-6bb0-42cf-a93d-e2cac970e424-2_E-Cliffs
+    lname.oldworldwhorl_grovevillage_topoda: ACTLocationData(rname.grove_village, 316, "Expired Grove - Village"), #8b9b3b77-b95f-46a2-adfd-ca962e8f0cef-2_E-Cliffs
 
     lname.bloodstar_flotsamvale_submerged: ACTLocationData(rname.flotsam_vale, 344, "Flotsam Vale"), #45cca266-a175-4020-9dd7-e0b844421aff-2_B-LowSwamp
     lname.oldworldwhorl_flotsamvale_cavepath: ACTLocationData(rname.flotsam_vale, 354, "Flotsam Vale"), #53cea11a-cfb6-4894-8e18-375ea895caed-2_A-HighSwamp
     lname.oldworldwhorl_flotsamvale_snail: ACTLocationData(rname.flotsam_vale, 357, "Flotsam Vale"), #32f43e6e-a382-4938-b068-f1eab35a0269-2_A-HighSwamp
-    lname.bloodstar_flotsamvale_craneclam: ACTLocationData(rname.flotsam_vale, 397, "Flotsam Vale"), #977f86dc-aeb1-471f-bb86-4db41bcbfc2c-2_A-HighSwamp
+    lname.bloodstar_flotsamvale_craneclam: ACTLocationData(rname.post_ceviche, 397, "Flotsam Vale - Post Ceviche Sisters"), #977f86dc-aeb1-471f-bb86-4db41bcbfc2c-2_A-HighSwamp
     lname.tacklepouch_flotsamvale_waterfall: ACTLocationData(rname.flotsam_vale, 403, "Flotsam Vale"), #b6c01d3a-31e3-457d-b53f-ecf0ff3b7e9f-2_B-LowSwamp
 
     lname.stainlessrelic_scuttleport_clam: ACTLocationData(rname.scuttleport, 438, "Scuttleport"), #95c7f334-5083-4ee8-bbcb-65033ca154f5-2_C-Facilities
@@ -377,7 +377,7 @@ location_table: Dict[str, ACTLocationData] = {
     ##### consumable item locations
     lname.barbedhook_reefsedge_undercoral: ACTLocationData(rname.reefs_edge, 65, "Reef's Edge"), #c44729ce-4c25-4059-8432-212381ca6835-2_A-NCTradeRoute
     lname.barbedhook_reefsedge_seahorses: ACTLocationData(rname.reefs_edge, 66, "Reef's Edge"), #08434b00-0100-4ea1-8f2a-f1567b84bdf2-2_A-NCTradeRoute
-    lname.barbedhook_reefsedge_shortcut: ACTLocationData(rname.reefs_edge, 69, "Reef's Edge"), #2b4849b0-2798-4600-8db1-c5d6bf6952b1-2_A-NCTradeRoute
+    lname.barbedhook_reefsedge_shortcut: ACTLocationData(rname.reefs_edge_grapple, 69, "Reef's Edge - Items Behind Grapple"), #2b4849b0-2798-4600-8db1-c5d6bf6952b1-2_A-NCTradeRoute
     lname.barbedhook_reefsedge_cliff: ACTLocationData(rname.reefs_edge, 72, "Reef's Edge"), #76ad26b0-4305-498c-8510-4940ad569210-2_A-NCTradeRoute
 
     lname.barbedhook_newcarcinia_citycenter: ACTLocationData(rname.new_carcinia, 78, "New Carcinia"), #c3b90e59-5289-4ca3-8639-a5c90d656403-2_B-NCCity
@@ -390,8 +390,8 @@ location_table: Dict[str, ACTLocationData] = {
     lname.barbedhook_sandsbetween_southcentral: ACTLocationData(rname.sands_between, 132, "The Sands Between"), #4ebb3072-53e8-4cff-9672-5f82f926035e-2_A-OOGroveRadius
     lname.barbedhook_sandsbetween_bobbitbase: ACTLocationData(rname.sands_between, 134, "The Sands Between"), #90171fe5-d483-4905-a440-a9ab5a7bc074-2_A-OOGroveRadius
     lname.barbedhook_sandsbetween_northofridge: ACTLocationData(rname.sands_between, 136, "The Sands Between"), #f8b96a25-70ba-492b-bb87-7b51c81d6102-2_A-OOGroveRadius
-    lname.barbedhook_sandsbetween_southeel: ACTLocationData(rname.sands_between, 152, "The Sands Between"), #771e0942-ebf4-4938-a7e7-c03ce67f9c16-2_A-OOGroveRadius
-    lname.barbedhook_sandsbetween_southeelshellsplitter: ACTLocationData(rname.sands_between, 154, "The Sands Between"), #a53aefd5-fa6f-4675-a1b5-2f9e43f3fed0-2_A-OOGroveRadius
+    lname.barbedhook_sandsbetween_southeel: ACTLocationData(rname.southern_town_ridge, 152, "The Sands Between - Southern Town Ridge"), #771e0942-ebf4-4938-a7e7-c03ce67f9c16-2_A-OOGroveRadius
+    lname.barbedhook_sandsbetween_southeelshellsplitter: ACTLocationData(rname.southern_town_ridge, 154, "The Sands Between - Southern Town Ridge"), #a53aefd5-fa6f-4675-a1b5-2f9e43f3fed0-2_A-OOGroveRadius
 
     lname.barbedhook_postpag_nechain: ACTLocationData(rname.post_pag, 173, "The Sands Between - Post Pagurus"), #a5c14863-82c3-47d0-b0e1-a67c93da96b8-2_A-OOGroveRadius
     lname.barbedhook_postpag_echain: ACTLocationData(rname.post_pag, 174, "The Sands Between - Post Pagurus"), #d2cd8afa-4bf2-490e-8542-cb92331800d6-2_A-OOGroveRadius
@@ -407,44 +407,44 @@ location_table: Dict[str, ACTLocationData] = {
     lname.barbedhook_ridge_overlookpath: ACTLocationData(rname.secluded_ridge, 192, "The Sands Between - Secluded Ridge"), #d9ee8d70-3493-4e7b-91b3-b42278ff0ad4-2_A-OOGroveRadius
     lname.sharkegg_ridge_broomspire: ACTLocationData(rname.secluded_ridge, 212, "The Sands Between - Secluded Ridge"), #dcc6b99e-1d47-481f-86ca-e14a5743f460-2_A-OOGroveRadius
 
-    lname.barbedhook_trashbin_eelgrapple: ACTLocationData(rname.secluded_ridge, 210, "The Sands Between - Trashbin Plateau"), #2bccca10-1f27-4762-9a9b-8e628586e0a4-2_A-OOGroveRadius
+    lname.barbedhook_trashbin_eelgrapple: ACTLocationData(rname.trashbin_plateau, 210, "The Sands Between - Trashbin Plateau"), #2bccca10-1f27-4762-9a9b-8e628586e0a4-2_A-OOGroveRadius
 
-    lname.barbedhook_grovemain_sniper: ACTLocationData(rname.secluded_ridge, 214, "Expired Grove Main"), #8fd70034-2415-4934-975b-2303d159f567-2_A-GroveForestLow
-    lname.barbedhook_grovemain_riverledge: ACTLocationData(rname.secluded_ridge, 215, "Expired Grove Main"), #0860891c-3db6-4e51-8c0b-58b09ac8ece0-2_A-GroveForestLow
-    lname.barbedhook_grovemain_riversand: ACTLocationData(rname.secluded_ridge, 216, "Expired Grove Main"), #2465aea2-9800-49e5-9e7e-d751ca2b3612-2_A-GroveForestLow
-    lname.barbedhook_grovemain_lichenthrope: ACTLocationData(rname.secluded_ridge, 221, "Expired Grove Main"), #35455018-8cf6-48db-ba76-4ffbca84b0a8-2_A-GroveForestLow
-    lname.barbedhook_grovemain_lichenthropeeast: ACTLocationData(rname.secluded_ridge, 222, "Expired Grove Main"), #5a106f4d-8139-44da-9cdf-8d0bd70c6bf3-2_A-GroveForestLow
-    lname.barbedhook_grovemain_sodacans: ACTLocationData(rname.secluded_ridge, 223, "Expired Grove Main"), #10a99891-923e-4bab-8057-b6d5781cb35d-2_A-GroveForestLow
-    lname.barbedhook_grovemain_acrossriver: ACTLocationData(rname.secluded_ridge, 228, "Expired Grove Main"), #50f9f7d1-0e70-4333-b8b3-fbc46f04f3ea-2_A-GroveForestLow
-    lname.barbedhook_grovemain_afternets: ACTLocationData(rname.secluded_ridge, 230, "Expired Grove Main"), #e7382e22-3232-4380-a734-bef8eb9a2a76-2_A-GroveForestLow
-    lname.barbedhook_grovemain_cartledge: ACTLocationData(rname.secluded_ridge, 235, "Expired Grove Main"), #dc13eb69-ac98-4de9-9fe0-7f16a03d4ebb-2_A-GroveForestLow
-    lname.barbedhook_grovemain_cartledgebottle: ACTLocationData(rname.secluded_ridge, 237, "Expired Grove Main"), #a5b6f3f6-6e1c-4934-9006-26da6cee47f4-2_A-GroveForestLow
-    lname.barbedhook_grovemain_paperplate: ACTLocationData(rname.secluded_ridge, 241, "Expired Grove Main"), #776881ba-f61b-4400-8cf5-f11fb11b6f94-2_B-GroveForestHigh
-    lname.barbedhook_grovemain_oildrum: ACTLocationData(rname.secluded_ridge, 242, "Expired Grove Main"), #12c73a88-beef-4bfb-a2d1-c159c91d8304-2_B-GroveForestHigh
-    lname.barbedhook_grovemain_canopy: ACTLocationData(rname.grove_main, 248, "Expired Grove Main"), #101eff6d-e09a-471d-86fd-cdc587012c32-2_A-GroveForestLow
-    lname.barbedhook_grovemain_drumtop: ACTLocationData(rname.secluded_ridge, 250, "Expired Grove Main"), #3a1e7a2c-5111-4360-b168-cc5e84088b6a-2_B-GroveForestHigh
-    lname.barbedhook_grovemain_carts: ACTLocationData(rname.grove_main, 259, "Expired Grove Main"), #d1b73602-aca6-4d33-991d-39110a5e6780-2_A-GroveForestLow
-    lname.sharkegg_grovemain_mantis: ACTLocationData(rname.grove_main, 260, "Expired Grove Main"), #f734eb5e-d674-4c84-9493-61d20f70fde3-2_A-GroveForestLow
+    lname.barbedhook_grovemain_sniper: ACTLocationData(rname.secluded_ridge, 214, "Expired Grove - Main"), #8fd70034-2415-4934-975b-2303d159f567-2_A-GroveForestLow
+    lname.barbedhook_grovemain_riverledge: ACTLocationData(rname.secluded_ridge, 215, "Expired Grove - Main"), #0860891c-3db6-4e51-8c0b-58b09ac8ece0-2_A-GroveForestLow
+    lname.barbedhook_grovemain_riversand: ACTLocationData(rname.secluded_ridge, 216, "Expired Grove - Main"), #2465aea2-9800-49e5-9e7e-d751ca2b3612-2_A-GroveForestLow
+    lname.barbedhook_grovemain_lichenthrope: ACTLocationData(rname.secluded_ridge, 221, "Expired Grove - Main"), #35455018-8cf6-48db-ba76-4ffbca84b0a8-2_A-GroveForestLow
+    lname.barbedhook_grovemain_lichenthropeeast: ACTLocationData(rname.secluded_ridge, 222, "Expired Grove  - Main"), #5a106f4d-8139-44da-9cdf-8d0bd70c6bf3-2_A-GroveForestLow
+    lname.barbedhook_grovemain_sodacans: ACTLocationData(rname.secluded_ridge, 223, "Expired Grove - Main"), #10a99891-923e-4bab-8057-b6d5781cb35d-2_A-GroveForestLow
+    lname.barbedhook_grovemain_acrossriver: ACTLocationData(rname.secluded_ridge, 228, "Expired Grove - Main"), #50f9f7d1-0e70-4333-b8b3-fbc46f04f3ea-2_A-GroveForestLow
+    lname.barbedhook_grovemain_afternets: ACTLocationData(rname.secluded_ridge, 230, "Expired Grove - Main"), #e7382e22-3232-4380-a734-bef8eb9a2a76-2_A-GroveForestLow
+    lname.barbedhook_grovemain_cartledge: ACTLocationData(rname.secluded_ridge, 235, "Expired Grove - Main"), #dc13eb69-ac98-4de9-9fe0-7f16a03d4ebb-2_A-GroveForestLow
+    lname.barbedhook_grovemain_cartledgebottle: ACTLocationData(rname.secluded_ridge, 237, "Expired Grove - Main"), #a5b6f3f6-6e1c-4934-9006-26da6cee47f4-2_A-GroveForestLow
+    lname.barbedhook_grovemain_paperplate: ACTLocationData(rname.secluded_ridge, 241, "Expired Grove - Main"), #776881ba-f61b-4400-8cf5-f11fb11b6f94-2_B-GroveForestHigh
+    lname.barbedhook_grovemain_oildrum: ACTLocationData(rname.secluded_ridge, 242, "Expired Grove - Main"), #12c73a88-beef-4bfb-a2d1-c159c91d8304-2_B-GroveForestHigh
+    lname.barbedhook_grovemain_canopy: ACTLocationData(rname.grove_raised_platforms, 248, "Expired Grove - Raised Platforms"), #101eff6d-e09a-471d-86fd-cdc587012c32-2_A-GroveForestLow
+    lname.barbedhook_grovemain_drumtop: ACTLocationData(rname.secluded_ridge, 250, "Expired Grove - Main"), #3a1e7a2c-5111-4360-b168-cc5e84088b6a-2_B-GroveForestHigh
+    lname.barbedhook_grovemain_carts: ACTLocationData(rname.grove_main, 259, "Expired Grove - Main"), #d1b73602-aca6-4d33-991d-39110a5e6780-2_A-GroveForestLow
+    lname.sharkegg_grovemain_mantis: ACTLocationData(rname.grove_main, 260, "Expired Grove - Main"), #f734eb5e-d674-4c84-9493-61d20f70fde3-2_A-GroveForestLow
 
-    lname.barbedhook_grovevillage_heikea: ACTLocationData(rname.grove_village, 287, "Expired Grove Village"), #bcfabbd4-8575-4a6a-8325-7259996a7d68-2_D-Caves
-    lname.barbedhook_grovevillage_cartfish: ACTLocationData(rname.grove_village, 271, "Expired Grove Village"), #7a38fbf2-47a9-4bf6-85d1-f8d4f58b8d66-2_B-GroveForestHigh
-    lname.barbedhook_grovevillage_riveroil: ACTLocationData(rname.grove_village, 273, "Expired Grove Village"), #9c983d04-ac83-40f0-8220-d92f76ea7099-2_B-GroveForestHigh
-    lname.barbedhook_grovevillage_bottles: ACTLocationData(rname.grove_village, 275, "Expired Grove Village"), #5c973136-cfe9-4ea5-bc93-60ffa4b5cc13-2_C-Village
-    lname.barbedhook_grovevillage_crabs: ACTLocationData(rname.grove_village, 277, "Expired Grove Village"), #4721ab20-67be-4d5b-b0bb-3f2c2ecb510f-2_C-Village
-    lname.barbedhook_grovevillage_centercarton: ACTLocationData(rname.grove_village, 278, "Expired Grove Village"), #bae2eb9a-56a0-4548-8c6d-798d234ba479-2_C-Village
-    lname.barbedhook_grovevillage_corpse: ACTLocationData(rname.grove_village, 279, "Expired Grove Village"), #20238db7-8d1e-4045-8e0a-de2aaea1cb49-2_C-Village
-    lname.barbedhook_grovevillage_path: ACTLocationData(rname.grove_village, 280, "Expired Grove Village"), #87e729ae-0659-4b6e-9ac1-c1d059719ba8-2_C-Village
-    lname.barbedhook_grovevillage_Ncarton: ACTLocationData(rname.grove_village, 282, "Expired Grove Village"), #b29402c2-62e8-4fa3-8c27-4e419750b16f-2_C-Village
-    lname.barbedhook_grovevillage_SWcarton: ACTLocationData(rname.grove_village, 284, "Expired Grove Village"), #256daaaa-675c-47e5-bd4e-367dc4abd9e2-2_C-Village
-    lname.sharkegg_grovevillage_sniper: ACTLocationData(rname.grove_village, 285, "Expired Grove Village"), #451f2fe5-9c29-4710-9493-0878963547e4-2_C-Village
-    lname.barbedhook_grovevillage_boat: ACTLocationData(rname.grove_village, 286, "Expired Grove Village"), #99c33625-2da4-4f69-a0af-8a8d2da3b399-2_D-Caves
-    lname.barbedhook_grovevillage_butter: ACTLocationData(rname.grove_village, 290, "Expired Grove Village"), #10eae42f-9cca-447a-8cb8-9cffcba11ecd-2_D-Caves
-    lname.barbedhook_grovevillage_above1: ACTLocationData(rname.grove_village, 301, "Expired Grove Village"), #28362ae0-defe-4a04-b449-93d7e5e60676-2_C-Village
-    lname.barbedhook_grovevillage_above2: ACTLocationData(rname.grove_village, 302, "Expired Grove Village"), #0177d8ef-8849-4ea4-b1b3-08a1c3134a99-2_E-Cliffs
-    lname.barbedhook_grovevillage_above3: ACTLocationData(rname.grove_village, 303, "Expired Grove Village"), #b3a776e1-52ab-4dc8-adc1-55c95eca9972-2_E-Cliffs
-    lname.barbedhook_grovevillage_ornament: ACTLocationData(rname.grove_village, 304, "Expired Grove Village"), #ce1700e2-d9d0-462a-af23-cb55828b062a-2_E-Cliffs
-    lname.barbedhook_grovevillage_hammer: ACTLocationData(rname.grove_village, 305, "Expired Grove Village"), #235b691b-0f18-4f35-bd8a-7536e12fabfe-2_E-Cliffs
-    lname.barbedhook_grovevillage_dock: ACTLocationData(rname.grove_village, 309, "Expired Grove Village"), #aff46c65-7a4a-4b1c-a0ca-840af3898f26-2_C-Village
+    lname.barbedhook_grovevillage_heikea: ACTLocationData(rname.grove_village, 287, "Expired Grove - Village"), #bcfabbd4-8575-4a6a-8325-7259996a7d68-2_D-Caves
+    lname.barbedhook_grovevillage_cartfish: ACTLocationData(rname.grove_village, 271, "Expired Grove - Village"), #7a38fbf2-47a9-4bf6-85d1-f8d4f58b8d66-2_B-GroveForestHigh
+    lname.barbedhook_grovevillage_riveroil: ACTLocationData(rname.grove_village, 273, "Expired Grove - Village"), #9c983d04-ac83-40f0-8220-d92f76ea7099-2_B-GroveForestHigh
+    lname.barbedhook_grovevillage_bottles: ACTLocationData(rname.grove_village, 275, "Expired Grove - Village"), #5c973136-cfe9-4ea5-bc93-60ffa4b5cc13-2_C-Village
+    lname.barbedhook_grovevillage_crabs: ACTLocationData(rname.grove_village, 277, "Expired Grove - Village"), #4721ab20-67be-4d5b-b0bb-3f2c2ecb510f-2_C-Village
+    lname.barbedhook_grovevillage_centercarton: ACTLocationData(rname.grove_village, 278, "Expired Grove - Village"), #bae2eb9a-56a0-4548-8c6d-798d234ba479-2_C-Village
+    lname.barbedhook_grovevillage_corpse: ACTLocationData(rname.grove_village, 279, "Expired Grove - Village"), #20238db7-8d1e-4045-8e0a-de2aaea1cb49-2_C-Village
+    lname.barbedhook_grovevillage_path: ACTLocationData(rname.grove_village, 280, "Expired Grove - Village"), #87e729ae-0659-4b6e-9ac1-c1d059719ba8-2_C-Village
+    lname.barbedhook_grovevillage_Ncarton: ACTLocationData(rname.grove_village, 282, "Expired Grove - Village"), #b29402c2-62e8-4fa3-8c27-4e419750b16f-2_C-Village
+    lname.barbedhook_grovevillage_SWcarton: ACTLocationData(rname.grove_village, 284, "Expired Grove - Village"), #256daaaa-675c-47e5-bd4e-367dc4abd9e2-2_C-Village
+    lname.sharkegg_grovevillage_sniper: ACTLocationData(rname.grove_village, 285, "Expired Grove - Village"), #451f2fe5-9c29-4710-9493-0878963547e4-2_C-Village
+    lname.barbedhook_grovevillage_boat: ACTLocationData(rname.grove_village, 286, "Expired Grove - Village"), #99c33625-2da4-4f69-a0af-8a8d2da3b399-2_D-Caves
+    lname.barbedhook_grovevillage_butter: ACTLocationData(rname.grove_village, 290, "Expired Grove - Village"), #10eae42f-9cca-447a-8cb8-9cffcba11ecd-2_D-Caves
+    lname.barbedhook_grovevillage_above1: ACTLocationData(rname.grove_village, 301, "Expired Grove - Village"), #28362ae0-defe-4a04-b449-93d7e5e60676-2_C-Village
+    lname.barbedhook_grovevillage_above2: ACTLocationData(rname.grove_village, 302, "Expired Grove - Village"), #0177d8ef-8849-4ea4-b1b3-08a1c3134a99-2_E-Cliffs
+    lname.barbedhook_grovevillage_above3: ACTLocationData(rname.grove_village, 303, "Expired Grove - Village"), #b3a776e1-52ab-4dc8-adc1-55c95eca9972-2_E-Cliffs
+    lname.barbedhook_grovevillage_ornament: ACTLocationData(rname.grove_village, 304, "Expired Grove - Village"), #ce1700e2-d9d0-462a-af23-cb55828b062a-2_E-Cliffs
+    lname.barbedhook_grovevillage_hammer: ACTLocationData(rname.grove_village, 305, "Expired Grove - Village"), #235b691b-0f18-4f35-bd8a-7536e12fabfe-2_E-Cliffs
+    lname.barbedhook_grovevillage_dock: ACTLocationData(rname.grove_village, 309, "Expired Grove - Village"), #aff46c65-7a4a-4b1c-a0ca-840af3898f26-2_C-Village
 
     lname.barbedhook_flotsamvale_entranceledge: ACTLocationData(rname.flotsam_vale, 338, "Flotsam Vale"), #17ac32ac-f0fc-4613-9e02-5ffdf4eecb63-2_B-LowSwamp
     lname.barbedhook_flotsamvale_entrancerocks: ACTLocationData(rname.flotsam_vale, 339, "Flotsam Vale"), #7aa4931c-e44f-4531-9b5e-eb1a01418fdd-2_B-LowSwamp
@@ -462,8 +462,8 @@ location_table: Dict[str, ACTLocationData] = {
     lname.barbedhook_flotsamvale_shippingsnail: ACTLocationData(rname.flotsam_vale, 398, "Flotsam Vale"), #1abd8a20-f2cc-488b-8e0a-00b12c305667-2_A-HighSwamp
     lname.barbedhook_flotsamvale_shippingbutane: ACTLocationData(rname.flotsam_vale, 399, "Flotsam Vale"), #a76a0b9b-6307-4b71-be91-da385c17a977-2_A-HighSwamp
     lname.barbedhook_flotsamvale_trashpile: ACTLocationData(rname.flotsam_vale, 402, "Flotsam Vale"), #a0549711-5560-4b9c-99d5-65e13911413a-2_A-HighSwamp
-    lname.barbedhook_flotsamvale_consortiumcage: ACTLocationData(rname.flotsam_vale, 405, "Flotsam Vale"), #7e76017e-13fa-4a96-a1f8-6d881b20b372-2_B-LowSwamp
-    lname.barbedhook_flotsamvale_consortium: ACTLocationData(rname.flotsam_vale, 408, "Flotsam Vale"), #b81ed4dc-3b3e-420d-99e9-d676c88fc120-2_B-LowSwamp
+    lname.barbedhook_flotsamvale_consortiumcage: ACTLocationData(rname.consortium_arena, 405, "Flotsam Vale - Consortium Arena"), #7e76017e-13fa-4a96-a1f8-6d881b20b372-2_B-LowSwamp
+    lname.barbedhook_flotsamvale_consortium: ACTLocationData(rname.consortium_arena, 408, "Flotsam Vale - Consortium Arena"), #b81ed4dc-3b3e-420d-99e9-d676c88fc120-2_B-LowSwamp
     lname.barbedhook_flotsamvale_snailfish: ACTLocationData(rname.flotsam_vale, 413, "Flotsam Vale"), #cdf2769f-deb3-43dc-841f-a4c1c0081833-2_A-HighSwamp
     lname.barbedhook_flotsamvale_westfish: ACTLocationData(rname.flotsam_vale, 420, "Flotsam Vale"), #698a076c-2661-4731-90c4-211d8b1414c6-2_A-HighSwamp
     lname.barbedhook_flotsamvale_behindcubby: ACTLocationData(rname.flotsam_vale, 605, "Flotsam Vale"), #5b786881-414b-41d4-97ea-b3a850d3633a-2_A-HighSwamp
@@ -508,7 +508,7 @@ location_table: Dict[str, ACTLocationData] = {
     ##### stowaway locations
     lname.siphonophore_shallows_westwall: ACTLocationData(rname.central_shallows, 31, "Central Shallows"),#4d4ac114-06e4-400f-b888-b500a7348cc9-2_B-ShallowsBigSand
     lname.seastar_shallows_eastledge: ACTLocationData(rname.central_shallows, 32, "Central Shallows"), #e9a5a6cf-2a19-4db5-bb0d-d85b260f3e2b-2_B-ShallowsBigSand
-    lname.sponge_shallows_puffer: ACTLocationData(rname.central_shallows, 33, "Central Shallows"), #95c0077d-518f-4ab7-85e2-ac1e0c1bb0b9-2_B-ShallowsBigSand
+    lname.sponge_shallows_puffer: ACTLocationData(rname.central_shallows_grapple, 33, "Central Shallows - Items Behind Grapple"), #95c0077d-518f-4ab7-85e2-ac1e0c1bb0b9-2_B-ShallowsBigSand
     lname.anothercrab_shallows_pillar: ACTLocationData(rname.central_shallows, 34, "Central Shallows"), #924670c2-839f-4e42-9cf5-8c081b17f946-2_B-ShallowsBigSand
     lname.sanddollar_shallows_arch: ACTLocationData(rname.central_shallows, 35, "Central Shallows"), #804d3848-3e86-474f-8622-547d020c4cc4-2_B-ShallowsBigSand
     lname.mussel_shallows_southwestcastlefish: ACTLocationData(rname.central_shallows, 125, "Central Shallows"), #41a6780e-55a2-4a0a-96a9-bb279a3b1ec3-2_B-ShallowsBigSand
@@ -527,7 +527,7 @@ location_table: Dict[str, ACTLocationData] = {
     lname.anemone_slacktide_fortwall: ACTLocationData(rname.slacktide_after, 41, "Fort Slacktide - After Destruction"), #557546a8-096b-49cd-b63b-452fb751a8bf-2_C-Slacktide2
     lname.whelk_slacktide_turrettop: ACTLocationData(rname.slacktide_after, 42, "Fort Slacktide - After Destruction"), #e1848736-945b-406d-853e-d213f7c80f14-2_C-Slacktide2
 
-    lname.seastar_reefsedge_crabs: ACTLocationData(rname.reefs_edge, 68, "Reef's Edge"), #d93f0715-7c15-4f74-b376-34468705093c-2_A-NCTradeRoute
+    lname.seastar_reefsedge_crabs: ACTLocationData(rname.reefs_edge_grapple, 68, "Reef's Edge - Items Behind Grapple"), #d93f0715-7c15-4f74-b376-34468705093c-2_A-NCTradeRoute
     lname.seastarplus_reefsedge_pole: ACTLocationData(rname.reefs_edge, 70, "Reef's Edge"), #3473ed8f-db06-4bb7-9932-862f92258542-2_A-NCTradeRoute
     lname.whelkplus_reefsedge_sponge: ACTLocationData(rname.reefs_edge, 73, "Reef's Edge"), #5e8a3fb6-f3b1-42a0-a8b8-10b57b340138-2_A-NCTradeRoute
 
@@ -556,9 +556,9 @@ location_table: Dict[str, ACTLocationData] = {
     lname.sinkerplus_sandsbetween_northridgemantis: ACTLocationData(rname.sands_between, 141,"The Sands Between"), #a8e01dfb-5dd9-4da0-92b1-39a7b18e8d83-2_A-OOGroveRadius
     lname.limpetplus_sandsbetween_grovemantis: ACTLocationData(rname.sands_between, 142,"The Sands Between"), #56e45097-4ffa-41b0-ac56-cdd6c93b5e88-2_A-OOGroveRadius
     lname.lumpsuckerplus_sandsbetween_anchor: ACTLocationData(rname.sands_between, 144,"The Sands Between"), #859c746b-c52f-4887-aa96-bb19bd7e25dd-2_A-OOGroveRadius
-    lname.sinkerplus_sandsbetween_southeel: ACTLocationData(rname.sands_between, 148,"The Sands Between"), #ae4a7ac6-5eb0-4590-a3c7-5d5f236a978d-2_A-OOGroveRadius
-    lname.musselplus_sandsbetween_southeel: ACTLocationData(rname.sands_between, 149,"The Sands Between"), #7111735c-772e-4c1f-b255-183e62760ae2-2_A-OOGroveRadius
-    lname.oyster_sandsbetween_southeelashtray: ACTLocationData(rname.sands_between, 153,"The Sands Between"), #2ccd3299-d207-4d4d-b5a5-d777c4e8aa29-2_A-OOGroveRadius
+    lname.sinkerplus_sandsbetween_southeel: ACTLocationData(rname.southern_town_ridge, 148,"The Sands Between - Southern Town Ridge"), #ae4a7ac6-5eb0-4590-a3c7-5d5f236a978d-2_A-OOGroveRadius
+    lname.musselplus_sandsbetween_southeel: ACTLocationData(rname.southern_town_ridge, 149,"The Sands Between - Southern Town Ridge"), #7111735c-772e-4c1f-b255-183e62760ae2-2_A-OOGroveRadius
+    lname.oyster_sandsbetween_southeelashtray: ACTLocationData(rname.southern_town_ridge, 153,"The Sands Between - Southern Town Ridge"), #2ccd3299-d207-4d4d-b5a5-d777c4e8aa29-2_A-OOGroveRadius
     lname.mussel_sandsbetween_bobbitfish: ACTLocationData(rname.sands_between, 159,"The Sands Between"), #da5f126f-e470-432c-b5b0-8eca9918ed77-2_A-OOGroveRadius
     lname.barnacle_sandsbetween_bobbitfish: ACTLocationData(rname.sands_between, 161,"The Sands Between"), #15cf7503-de68-4475-b39c-fe687f85c448-2_A-OOGroveRadius
     lname.whelkplusplus_sandsbetween_southeelpeak: ACTLocationData(rname.sands_between, 166,"The Sands Between"), #d61a21a2-c27d-45d7-8e11-75fcd11e8b78-2_A-OOGroveRadius
@@ -569,35 +569,35 @@ location_table: Dict[str, ACTLocationData] = {
     lname.sanddollar_ridge_broom: ACTLocationData(rname.secluded_ridge, 194, "The Sands Between - Secluded Ridge"), #42686eee-4b9f-4d44-a52d-569d2c814f13-2_A-OOGroveRadius
     lname.musselplus_ridge_togo: ACTLocationData(rname.secluded_ridge, 196, "The Sands Between - Secluded Ridge"), #a59b9d02-9711-48e3-8296-e2164c79f1f2-2_A-OOGroveRadius
     lname.siphonophoreplus_ridge_pitfall: ACTLocationData(rname.secluded_ridge, 203, "The Sands Between - Secluded Ridge"), #e2a1e3e1-8ee4-4539-ab81-98c4d6d99630-2_A-OOGroveRadius
-    lname.anemoneplus_ridge_eel: ACTLocationData(rname.secluded_ridge, 204, "The Sands Between - Secluded Ridge"), #1b6f2070-3ff2-4f48-b061-0a41990013e1-2_A-OOGroveRadius
-    lname.cockle_ridge_eelfish: ACTLocationData(rname.secluded_ridge, 208, "The Sands Between - Secluded Ridge"), #d32ade52-c34e-4cb7-957c-df605339ee4c-2_A-OOGroveRadius
+    lname.anemoneplus_ridge_eel: ACTLocationData(rname.secluded_ridge_eel, 204, "The Sands Between - Secluded Ridge Eelectrocute"), #1b6f2070-3ff2-4f48-b061-0a41990013e1-2_A-OOGroveRadius
+    lname.cockle_ridge_eelfish: ACTLocationData(rname.secluded_ridge_eel, 208, "The Sands Between - Secluded Ridge Eelectrocute"), #d32ade52-c34e-4cb7-957c-df605339ee4c-2_A-OOGroveRadius
     lname.bobber_ridge_broomspire: ACTLocationData(rname.secluded_ridge, 211, "The Sands Between - Secluded Ridge"), #fc2cf7ed-6ff6-40bb-987a-936da0afa93b-2_A-OOGroveRadius
 
-    lname.cockle_trashbin_peak: ACTLocationData(rname.secluded_ridge, 199, "The Sands Between - Trashbin Plateau"), #ca4c297f-e9fd-4a78-b89a-811d2394406b-2_A-OOGroveRadius
-    lname.sinker_trashbin_peak: ACTLocationData(rname.secluded_ridge, 200, "The Sands Between - Trashbin Plateau"), #36611427-18cc-45f3-ad50-a51cc02ccb1d-2_A-OOGroveRadius
-    lname.smallbattery_trashbin_mantis: ACTLocationData(rname.secluded_ridge, 201, "The Sands Between - Trashbin Plateau"), #0d86fe0e-ae41-4fb2-beb2-9bb5e558429a-2_A-OOGroveRadius
-    lname.googlyeye_trashbin_pineapple: ACTLocationData(rname.secluded_ridge, 202, "The Sands Between - Trashbin Plateau"), #7935fe1e-318c-4f90-901b-fa001de6e4dc-2_A-OOGroveRadius
+    lname.cockle_trashbin_peak: ACTLocationData(rname.trashbin_plateau, 199, "The Sands Between - Trashbin Plateau"), #ca4c297f-e9fd-4a78-b89a-811d2394406b-2_A-OOGroveRadius
+    lname.sinker_trashbin_peak: ACTLocationData(rname.trashbin_plateau, 200, "The Sands Between - Trashbin Plateau"), #36611427-18cc-45f3-ad50-a51cc02ccb1d-2_A-OOGroveRadius
+    lname.smallbattery_trashbin_mantis: ACTLocationData(rname.trashbin_plateau, 201, "The Sands Between - Trashbin Plateau"), #0d86fe0e-ae41-4fb2-beb2-9bb5e558429a-2_A-OOGroveRadius
+    lname.googlyeye_trashbin_pineapple: ACTLocationData(rname.trashbin_plateau, 202, "The Sands Between - Trashbin Plateau"), #7935fe1e-318c-4f90-901b-fa001de6e4dc-2_A-OOGroveRadius
 
-    lname.barnacle_grovemain_colander: ACTLocationData(rname.grove_main, 213, "Expired Grove Main"), #74aa4107-6a5a-4868-ae54-942e4421be3f-2_A-GroveForestLow
-    lname.seastar_grovemain_eastrock: ACTLocationData(rname.grove_main, 218, "Expired Grove Main"), #17cb1eed-8d88-4464-b33b-215c837035f6-2_A-GroveForestLow
-    lname.pufferquill_grovemain_sponges: ACTLocationData(rname.grove_main, 220, "Expired Grove Main"), #c6a56f3d-c134-41cd-83b7-4a755fa32284-2_A-GroveForestLow
-    lname.limpet_grovemain_sodacan: ACTLocationData(rname.grove_main, 236, "Expired Grove Main"), #093c4972-ff5e-4ba6-b9a8-136411e1017f-2_A-GroveForestLow
-    lname.lumpsucker_grovemain_canopy: ACTLocationData(rname.grove_main, 247, "Expired Grove Main"), #3789e56d-69b5-4d6c-adb1-6454b101840d-2_A-GroveForestLow
-    lname.anothercrab_grovemain_sniper: ACTLocationData(rname.grove_main, 619, "Expired Grove Main"), #8e4714bf-cc7f-4bde-9c88-7fcdbf8d0afe-2_A-GroveForestLow
-    lname.sharktooth_grovemain_pizza: ACTLocationData(rname.grove_main, 251, "Expired Grove Main"), #8e34f6a5-5844-4767-ab15-4fbaf6c147dc-2_B-GroveForestHigh
-    lname.contactlens_grovemain_carts: ACTLocationData(rname.grove_main, 262, "Expired Grove Main"), #0e278f86-0f9d-468f-95b2-586df2a94689-2_A-GroveForestLow
-    lname.cottonball_grovemain_mantis: ACTLocationData(rname.grove_main, 263, "Expired Grove Main"), #fa3cfc64-4f87-452c-bf59-4f599cb3f6fa-2_A-GroveForestLow
-    lname.mussel_grovemain_fishing: ACTLocationData(rname.grove_main, 264, "Expired Grove Main"), #a1c14883-bc09-441c-a188-20dabf047532-2_A-GroveForestLow
-    lname.sponge_grovemain_fishing: ACTLocationData(rname.grove_main, 265, "Expired Grove Main"), #7aa1847-5a38-4f15-a6fc-90c15cd9baf7-2_A-GroveForestLow
-    lname.oyster_grovemain_fishing: ACTLocationData(rname.grove_main, 266, "Expired Grove Main"), #6ce4acf2-09a4-43ca-9be7-5d79a9d5c781-2_A-GroveForestLow
-    lname.limpet_grovemain_fishing: ACTLocationData(rname.grove_main, 267, "Expired Grove Main"), #027511ce-7f48-480e-91af-18b4c7aaa57d-2_A-GroveForestLow
+    lname.barnacle_grovemain_colander: ACTLocationData(rname.grove_main, 213, "Expired Grove - Main"), #74aa4107-6a5a-4868-ae54-942e4421be3f-2_A-GroveForestLow
+    lname.seastar_grovemain_eastrock: ACTLocationData(rname.grove_main, 218, "Expired Grove - Main"), #17cb1eed-8d88-4464-b33b-215c837035f6-2_A-GroveForestLow
+    lname.pufferquill_grovemain_sponges: ACTLocationData(rname.grove_main, 220, "Expired Grove - Main"), #c6a56f3d-c134-41cd-83b7-4a755fa32284-2_A-GroveForestLow
+    lname.limpet_grovemain_sodacan: ACTLocationData(rname.grove_main, 236, "Expired Grove - Main"), #093c4972-ff5e-4ba6-b9a8-136411e1017f-2_A-GroveForestLow
+    lname.lumpsucker_grovemain_canopy: ACTLocationData(rname.grove_raised_platforms, 247, "Expired Grove - Raised Platforms"), #3789e56d-69b5-4d6c-adb1-6454b101840d-2_A-GroveForestLow
+    lname.anothercrab_grovemain_sniper: ACTLocationData(rname.grove_main, 619, "Expired Grove - Main"), #8e4714bf-cc7f-4bde-9c88-7fcdbf8d0afe-2_A-GroveForestLow
+    lname.sharktooth_grovemain_pizza: ACTLocationData(rname.grove_main, 251, "Expired Grove - Main"), #8e34f6a5-5844-4767-ab15-4fbaf6c147dc-2_B-GroveForestHigh
+    lname.contactlens_grovemain_carts: ACTLocationData(rname.grove_main, 262, "Expired Grove - Main"), #0e278f86-0f9d-468f-95b2-586df2a94689-2_A-GroveForestLow
+    lname.cottonball_grovemain_mantis: ACTLocationData(rname.grove_main, 263, "Expired Grove - Main"), #fa3cfc64-4f87-452c-bf59-4f599cb3f6fa-2_A-GroveForestLow
+    lname.mussel_grovemain_fishing: ACTLocationData(rname.grove_main, 264, "Expired Grove - Main"), #a1c14883-bc09-441c-a188-20dabf047532-2_A-GroveForestLow
+    lname.sponge_grovemain_fishing: ACTLocationData(rname.grove_main, 265, "Expired Grove - Main"), #7aa1847-5a38-4f15-a6fc-90c15cd9baf7-2_A-GroveForestLow
+    lname.oyster_grovemain_fishing: ACTLocationData(rname.grove_main, 266, "Expired Grove - Main"), #6ce4acf2-09a4-43ca-9be7-5d79a9d5c781-2_A-GroveForestLow
+    lname.limpet_grovemain_fishing: ACTLocationData(rname.grove_main, 267, "Expired Grove - Main"), #027511ce-7f48-480e-91af-18b4c7aaa57d-2_A-GroveForestLow
 
-    lname.anemone_grovevillage_fishing: ACTLocationData(rname.grove_village, 274, "Expired Grove Village"), #5e81380f-3e8f-4d44-a0ef-ebbad0f23fdb-2_B-GroveForestHigh
-    lname.phytoplanktonplus_grovevillage_upsidedown: ACTLocationData(rname.grove_village, 300, "Expired Grove Village"), #03bc01f8-4691-40b7-93c6-4d45563b5b46-2_C-Village
-    lname.wadofgum_grovevillage_gumpile: ACTLocationData(rname.grove_village, 306, "Expired Grove Village"), #ab2ba852-edf4-467f-a1f5-1825341b7596-2_E-Cliffs
-    lname.anemone_grovevillage_seahorse: ACTLocationData(rname.grove_village, 308, "Expired Grove Village"), #32841813-148d-45f7-8c4e-4464f157200d-2_E-Cliffs
-    lname.mussel_grovevillage_dock: ACTLocationData(rname.grove_village, 310, "Expired Grove Village"), #3f1f877c-e5ac-40d1-93b7-2245282b0669-2_C-Village
-    lname.earthworm_grovevillage_dock: ACTLocationData(rname.grove_village, 313, "Expired Grove Village"), #725998d5-172d-4408-9f70-0f9264a6a6fd-2_C-Village
+    lname.anemone_grovevillage_fishing: ACTLocationData(rname.grove_village, 274, "Expired Grove - Village"), #5e81380f-3e8f-4d44-a0ef-ebbad0f23fdb-2_B-GroveForestHigh
+    lname.phytoplanktonplus_grovevillage_upsidedown: ACTLocationData(rname.grove_village, 300, "Expired Grove - Village"), #03bc01f8-4691-40b7-93c6-4d45563b5b46-2_C-Village
+    lname.wadofgum_grovevillage_gumpile: ACTLocationData(rname.grove_village, 306, "Expired Grove - Village"), #ab2ba852-edf4-467f-a1f5-1825341b7596-2_E-Cliffs
+    lname.anemone_grovevillage_seahorse: ACTLocationData(rname.grove_village, 308, "Expired Grove - Village"), #32841813-148d-45f7-8c4e-4464f157200d-2_E-Cliffs
+    lname.mussel_grovevillage_dock: ACTLocationData(rname.grove_village, 310, "Expired Grove - Village"), #3f1f877c-e5ac-40d1-93b7-2245282b0669-2_C-Village
+    lname.earthworm_grovevillage_dock: ACTLocationData(rname.grove_village, 313, "Expired Grove - Village"), #725998d5-172d-4408-9f70-0f9264a6a6fd-2_C-Village
 
     lname.anemone_flotsamvale_butaneisland: ACTLocationData(rname.flotsam_vale, 346, "Flotsam Vale"), #76b9b9ce-875c-4136-a6da-dabdfc70d40e-2_B-LowSwamp
     lname.rustynail_flotsamvale_brokenbutane: ACTLocationData(rname.flotsam_vale, 350, "Flotsam Vale"), #d656b2e6-15ec-4e24-bebb-94c1ed7f6c30-2_B-LowSwamp
@@ -605,6 +605,8 @@ location_table: Dict[str, ACTLocationData] = {
     lname.mussel_flotsamvale_woodplatform: ACTLocationData(rname.flotsam_vale, 363, "Flotsam Vale"), #e5b02de1-7cb7-4a4d-98a9-369c44302cac-2_A-HighSwamp
     lname.rustynail_flotsamvale_steamroller: ACTLocationData(rname.flotsam_vale, 367, "Flotsam Vale"), #f8d826c0-7319-4f95-ab90-bf28a7218dfb-2_A-HighSwamp
     lname.limpet_flotsamvale_trashpile: ACTLocationData(rname.flotsam_vale, 368, "Flotsam Vale"), #855a1efa-0f38-4e6b-a68d-24a991dcac42-2_A-HighSwamp
+    lname.barnacle_flotsamvale_steamroller: ACTLocationData(rname.post_ceviche, 607, "Flotsam Vale - Post Ceviche Sisters"), #TODO update index
+    #9545c7d7-0ea6-457b-ad4d-c744984f0d79-2_A-HighSwamp
     lname.fruitsticker_flotsamvale_westbutane: ACTLocationData(rname.flotsam_vale, 371, "Flotsam Vale"), #0ad3895d-4612-4856-a6ed-7a7b48f2c36f-2_A-HighSwamp
     lname.seacucumber_flotsamvale_westbutane: ACTLocationData(rname.flotsam_vale, 372, "Flotsam Vale"), #5ccf4e25-ff98-4a9a-9e31-2eea57589809-2_A-HighSwamp
     lname.lumpsucker_flotsamvale_shorcut: ACTLocationData(rname.flotsam_vale, 375, "Flotsam Vale"), #a569d9f6-d930-4a9b-8041-8eb8621532ac-2_A-HighSwamp
@@ -614,7 +616,7 @@ location_table: Dict[str, ACTLocationData] = {
     lname.cockle_flotsamvale_APabove: ACTLocationData(rname.flotsam_vale, 390, "Flotsam Vale"), #aeb3f185-eb51-4e68-a0cc-6dafc4b48a11-2_A-HighSwamp
     lname.sanddollar_flotsamvale_APabove: ACTLocationData(rname.flotsam_vale, 392, "Flotsam Vale"), #812367fb-0264-4113-9da5-104ba61d368b-2_A-HighSwamp
     lname.anemoneplus_flotsamvale_APunder: ACTLocationData(rname.flotsam_vale, 393, "Flotsam Vale"), #35d5823c-2da6-48c4-b8f1-074221917090-2_A-HighSwamp
-    lname.anothercrab_flotsamvale_mailbox: ACTLocationData(rname.flotsam_vale, 395, "Flotsam Vale"), #daf9fa57-89d6-481f-8a6d-c32c9e8ecb5a-2_A-HighSwamp
+    lname.anothercrab_flotsamvale_mailbox: ACTLocationData(rname.post_ceviche, 395, "Flotsam Vale - Post Ceviche Sisters"), #daf9fa57-89d6-481f-8a6d-c32c9e8ecb5a-2_A-HighSwamp
     lname.sponge_flotsamvale_cranegrapple: ACTLocationData(rname.flotsam_vale, 407, "Flotsam Vale"), #2cb7f595-94fa-4b7b-a7c6-602808292c48-2_A-HighSwamp
     lname.seastarplus_flotsamvale_submerged: ACTLocationData(rname.flotsam_vale, 410, "Flotsam Vale"), #89d10f86-fcf2-483a-b145-f1576682520c-2_A-HighSwamp
     lname.lamprey_flotsamvale_islandfish: ACTLocationData(rname.flotsam_vale, 411, "Flotsam Vale"), #5a5395f1-e087-4a30-b3ea-b055fd328d40-2_B-LowSwamp
@@ -685,7 +687,7 @@ location_table: Dict[str, ACTLocationData] = {
     lname.captain_costume_pickup: ACTLocationData(rname.central_shallows, 43, "Central Shallows"), #7c307763-a7b4-4e81-88d6-e1baf1b04608-2_B-ShallowsBigSand
     lname.clown_costume_pickup: ACTLocationData(rname.sands_between, 140,"The Sands Between"), #cd2d0535-6c06-4530-bf60-afbffc2d5086-2_A-OOGroveRadius
     lname.sunlight_costume_pickup: ACTLocationData(rname.secluded_ridge, 198, "The Sands Between - Secluded Ridge"), #35aa72f2-fa50-4efc-b600-b597382ed877-2_A-OOGroveRadius
-    lname.intern_costume_pickup: ACTLocationData(rname.grove_village, 296, "Expired Grove Village"), #4ba7f2ff-ff35-4d74-b5ac-d9c59fe1c94d-2_C-Village
+    lname.intern_costume_pickup: ACTLocationData(rname.grove_village, 296, "Expired Grove - Village"), #4ba7f2ff-ff35-4d74-b5ac-d9c59fe1c94d-2_C-Village
     lname.cowfishboy_costume_pickup: ACTLocationData(rname.flotsam_vale, 348, "Flotsam Vale"), #b1f8794b-d43d-41b9-827a-75bb4c7a57bf-NickGym
     lname.bluecollar_costume_pickup: ACTLocationData(rname.scuttleport, 430, "Scuttleport"), #f37cb96e-df05-4aed-b2b5-7d8d5af32483-NickGym
     lname.krillionaire_costume_pickup: ACTLocationData(rname.unfathom, 490, "The Unfathom"), #c762c7f8-33b6-4701-9f4c-7ad7938a5d11-2_B-DarkCanyon

--- a/worlds/another_crab/locations.py
+++ b/worlds/another_crab/locations.py
@@ -142,44 +142,46 @@ location_table: Dict[str, ACTLocationData] = {
 
     lname.stapleclaw_trashbin_eelfish: ACTLocationData(rname.trashbin_plateau, 209, "The Sands Between - Trashbin Plateau"), #190034bb-c13e-42ec-bac4-037cc828fde3-2_A-OOGroveRadius
 
-    lname.breadclaw_grovemain_takeout: ACTLocationData(rname.grove_main, 219, "Expired Grove - Main"), #4933d4b0-a56a-4472-b9a6-4469fd335fa4-2_A-GroveForestLow
-    lname.breadclaw_grovemain_tiretop: ACTLocationData(rname.grove_main, 224, "Expired Grove - Main"), #da04ed8f-2d99-48f9-8412-67748d983d2b-2_A-GroveForestLow
-    lname.chipclaw_grovemain_plastic: ACTLocationData(rname.grove_main, 225, "Expired Grove - Main"), #902c2deb-1b51-4226-9fd0-1c76bea668c3-2_A-GroveForestLow
-    lname.clothesclaw_grovemain_choccymilk: ACTLocationData(rname.grove_main, 226, "Expired Grove - Main"), #e38ef2da-daaf-4312-bf7f-2e0a97d3d67b-2_A-GroveForestLow
-    lname.breadclaw_grovemain_insidetire: ACTLocationData(rname.grove_main, 227, "Expired Grove - Main"), #def84515-cfc0-4124-a1e1-81f6953b0c06-2_A-GroveForestLow
-    lname.chipclaw_grovemain_sniper: ACTLocationData(rname.grove_main, 245, "Expired Grove - Main"), #070b84a6-7a8b-4d88-8216-f55882856713-2_A-GroveForestLow
-    lname.hairclaw_grovemain_milkurchins: ACTLocationData(rname.grove_main, 246, "Expired Grove - Main"), #e78f03e8-2827-45d7-8cfa-cbaa0f17cd3d-2_A-GroveForestLow
-    lname.breadclaw_grovemain_smallhall: ACTLocationData(rname.grove_main, 231, "Expired Grove - Main"), #be378f83-9ec2-4a3b-85b2-9a7499e6d693-2_A-GroveForestLow
+    lname.breadclaw_grovemain_takeout: ACTLocationData(rname.grove_main, 219, "Expired Grove - Main"), #7d3ea7ae-4d80-4618-b798-39ba032f7650-2_A-GroveForestLow
+    lname.breadclaw_grovemain_tiretop: ACTLocationData(rname.grove_main, 224, "Expired Grove - Main"), #075bc58b-ab5e-41cc-b82b-89f7c897821a-2_A-GroveForestLow
+    lname.chipclaw_grovemain_plastic: ACTLocationData(rname.grove_main, 225, "Expired Grove - Main"), #af194776-481c-4198-aa8b-baf05f24de1b-2_A-GroveForestLow
+    lname.clothesclaw_grovemain_choccymilk: ACTLocationData(rname.grove_main, 226, "Expired Grove - Main"), # 6ad0a92e-48c3-40e6-9f3c-746fd78cf376-2_A-GroveForestLow
+    lname.breadclaw_grovemain_insidetire: ACTLocationData(rname.grove_main, 227, "Expired Grove - Main"), #90bfa7e8-b69f-4e3b-b539-967c7df38523-2_A-GroveForestLow
+    lname.chipclaw_grovemain_sniper: ACTLocationData(rname.grove_main, 245, "Expired Grove - Main"), #9ca18539-8fd5-4def-9418-c17bbb1f0d65-2_A-GroveForestLow
+    lname.hairclaw_grovemain_milkurchins: ACTLocationData(rname.grove_main, 246, "Expired Grove - Main"), #df6fcb07-437c-4b21-b207-5a9e8e37cccb-2_A-GroveForestLow
     lname.chipclaw_grovemain_apples: ACTLocationData(rname.grove_main, 232, "Expired Grove - Main"), #faa3c9ce-87c7-4f6d-b07e-be334c3bc447-2_A-GroveForestLow
     lname.chipclaw_grovemain_sodacans: ACTLocationData(rname.grove_main, 233, "Expired Grove - Main"), #25737275-a222-4a6e-af6b-0c66c197cab7-2_A-GroveForestLow
-    lname.hairclaw_grovemain_moonshine: ACTLocationData(rname.grove_main, 234, "Expired Grove - Main"), #fd557b69-ddba-4b14-bd80-f0cb0d786203-2_A-GroveForestLow
+    lname.hairclaw_grovemain_moonshine: ACTLocationData(rname.grove_main, 234, "Expired Grove - Main"), #1c84843a-ab7e-433f-b376-83a0373f5a97-2_A-GroveForestLow
     lname.chipclaw_grovemain_circlerock: ACTLocationData(rname.grove_main, 238, "Expired Grove - Main"), #1b74ef4f-528c-484b-9a5f-abbb3434f133-2_A-GroveForestLow
     lname.clothesclaw_grovemain_alcove: ACTLocationData(rname.grove_main, 239, "Expired Grove - Main"), #f99a120b-43c2-4e65-91fd-71cbfbf3e8f7-2_A-GroveForestLow
     lname.hairclaw_grovemain_sniper: ACTLocationData(rname.grove_raised_platforms, 240, "Expired Grove - Raised Platforms"), #8f4a1f33-e567-4c84-b34b-739353b3ba08-2_A-GroveForestLow
     lname.breadclaw_grovemain_amongus: ACTLocationData(rname.grove_main, 243, "Expired Grove - Main"), #c859129f-cc29-4624-a161-fdeffa00d0ca-2_B-GroveForestHigh
     lname.breadclaw_grovemain_oildrum: ACTLocationData(rname.grove_main, 244, "Expired Grove - Main"), #b85cb09c-f1d7-4396-85cb-fde4dc845acd-2_B-GroveForestHigh
     lname.breadclaw_grovemain_oilgrapple: ACTLocationData(rname.grove_main, 249, "Expired Grove - Main"), #bc18b92b-a6c6-420c-9095-e15c34c2f921-2_B-GroveForestHigh
-    lname.clothesclaw_grovemain_mantisfish: ACTLocationData(rname.grove_main, 256, "Expired Grove - Main"), #048736b5-59c1-4dd2-b36a-e11b6bd9304f-2_A-GroveForestLow
-    lname.hairclaw_grovemain_fishing: ACTLocationData(rname.grove_main, 257, "Expired Grove - Main"), #23907bde-1820-4c4d-9c59-aab72c64139a-2_A-GroveForestLow
+    lname.clothesclaw_grovemain_mantisfish: ACTLocationData(rname.grove_main, 256, "Expired Grove - Main"), #789ed5bd-38ce-4539-8f1c-135cc3c89377-2_A-GroveForestLow
+    lname.hairclaw_grovemain_fishing: ACTLocationData(rname.grove_main, 257, "Expired Grove - Main"), #24079978-2320-428e-9096-71aa2d20fb9c-2_A-GroveForestLow
     lname.clothesclaw_grovemain_riverfish: ACTLocationData(rname.grove_main, 258, "Expired Grove - Main"), #ebad553d-fbff-441e-8c1d-0ccc65fe81ae-2_A-GroveForestLow
+    lname.clothesclaw_grovemain_waterfall: ACTLocationData(rname.grove_main, 621, "Expired Grove - Main"),
+    #cb589bcb-04b5-412d-a8a0-8502b584083b-2_A-GroveForestLow
+    lname.hairclaw_grovemain_afternets: ACTLocationData(rname.secluded_ridge, 230, "Expired Grove - Main"), #886641b3-08c7-4460-97dc-56d52e2e24c9-2_A-GroveForestLow
 
     lname.breadclaw_grovevillage_oildrum: ACTLocationData(rname.grove_village, 268, "Expired Grove - Village"), #66a4a627-ad3a-45d6-aaf1-1e505dac0495-2_B-GroveForestHigh
     lname.breadclaw_grovevillage_bottle1: ACTLocationData(rname.grove_village, 269, "Expired Grove - Village"), #a6e719fc-65b0-4c3a-830e-43065a819c7d-2_B-GroveForestHigh
     lname.breadclaw_grovevillage_bottle2: ACTLocationData(rname.grove_village, 270, "Expired Grove - Village"), #507a5ca4-3de6-4d85-ba51-04c1e42c891e-2_B-GroveForestHigh
     lname.chipclaw_grovevillage_netorbs: ACTLocationData(rname.grove_village, 253, "Expired Grove - Village"), #df0386e0-99ee-478a-873d-b40e973fc16b-2_D-Caves
     lname.hairclaw_grovevillage_river: ACTLocationData(rname.grove_village, 272, "Expired Grove - Village"), #ec08fee3-e62f-45ee-9fbe-9101522d4f30-2_B-GroveForestHigh
-    lname.chipclaw_grovevillage_NWcarton: ACTLocationData(rname.grove_village, 276, "Expired Grove - Village"), #84c9cc27-0876-4e4d-a9e2-c28f06abdfc3-2_C-Village
-    lname.chipclaw_grovevillage_SEcarton: ACTLocationData(rname.grove_village, 281, "Expired Grove - Village"), #c83c8f42-474a-4dd4-bbae-99df2ad1681a-2_C-Village
-    lname.chipclaw_grovevillage_NEcarton: ACTLocationData(rname.grove_village, 283, "Expired Grove - Village"), #1cd62e82-14b4-4a8a-8dc1-7e8f0ff9b11b-2_C-Village
+    lname.chipclaw_grovevillage_NWcarton: ACTLocationData(rname.grove_village, 276, "Expired Grove - Village"), #4fc8b860-3980-4dba-9a04-622ca685f58a-2_C-Village
+    lname.chipclaw_grovevillage_SEcarton: ACTLocationData(rname.grove_village, 281, "Expired Grove - Village"), #541eece9-d2ae-46c6-8799-6c8fce1038ba-2_C-Village
+    lname.chipclaw_grovevillage_NEcarton: ACTLocationData(rname.grove_village, 283, "Expired Grove - Village"), #34fca9ff-ebdc-4e26-955b-acda73df419d-2_C-Village
     lname.breadclaw_grovevillage_shortcut: ACTLocationData(rname.grove_village, 289, "Expired Grove - Village"), #ff8f29f4-2859-4ff7-857f-54e0a9c185fa-2_D-Caves
     lname.chipclaw_grovevillage_cave: ACTLocationData(rname.grove_village, 291, "Expired Grove - Village"), #6dbab2ee-2440-4b3d-944e-688f11a88199-2_D-Caves
     lname.hairclaw_grovevillage_entrance: ACTLocationData(rname.grove_village, 292, "Expired Grove - Village"), #7434f4f5-8e47-40f0-b3a3-507ada236333-2_D-Caves
-    lname.breadclaw_grovevillage_Scarton: ACTLocationData(rname.grove_village, 293, "Expired Grove - Village"), #b1b6be9e-1973-4562-8e96-43adf0d8fcd5-2_C-Village
-    lname.breadclaw_grovevillage_entrance: ACTLocationData(rname.grove_village, 294, "Expired Grove - Village"), #dc39a6c7-45be-4e9a-9ac2-4da3094395dd-2_C-Village
-    lname.hairclaw_grovevillage_NEcarton: ACTLocationData(rname.grove_village, 297, "Expired Grove - Village"), #3eee4944-4b1e-4680-92de-0ee564c91330-2_C-Village
-    lname.clothesclaw_grovevillage_upsidedown: ACTLocationData(rname.grove_village, 299, "Expired Grove - Village"), #8e368d78-572e-4fed-8607-2fb4c35b23e8-2_C-Village
-    lname.clothesclaw_grovevillage_dock: ACTLocationData(rname.grove_village, 311, "Expired Grove - Village"), #2a160afc-7439-4e22-9f2b-62fa152f6626-2_C-Village
-    lname.hairclaw_grovevillage_dock: ACTLocationData(rname.grove_village, 312, "Expired Grove - Village"), #08e5033e-a401-4e90-a1a5-7e9e76ed72a5-2_C-Village
+    lname.breadclaw_grovevillage_Scarton: ACTLocationData(rname.grove_village, 293, "Expired Grove - Village"), #a14ac78c-615a-45a5-a4f9-c286c98d99f8-2_C-Village
+    lname.breadclaw_grovevillage_entrance: ACTLocationData(rname.grove_village, 294, "Expired Grove - Village"), #a4867b74-b444-42b0-ae95-be5e1044f19e-2_C-Village
+    lname.hairclaw_grovevillage_NEcarton: ACTLocationData(rname.grove_village, 297, "Expired Grove - Village"), #b7d86492-a9c9-43fd-bf07-5bd35196ce10-2_C-Village
+    lname.clothesclaw_grovevillage_upsidedown: ACTLocationData(rname.grove_village, 299, "Expired Grove - Village"), #37b6c80a-20cc-4a2d-ba70-5e755ee13620-2_C-Village
+    lname.clothesclaw_grovevillage_dock: ACTLocationData(rname.grove_village, 311, "Expired Grove - Village"), #b5f18ebb-b325-4b01-802c-8aac4a902cf0-2_C-Village
+    lname.hairclaw_grovevillage_dock: ACTLocationData(rname.grove_village, 312, "Expired Grove - Village"), #26975cc9-71ac-4f09-a523-99331c45a6ae-2_C-Village
     lname.clothesclaw_grovevillage_hidden: ACTLocationData(rname.grove_village, 314, "Expired Grove - Village"), #3bd305d9-8d6b-43c4-99c7-1f2be904de06-2_E-Cliffs
     lname.carclaw_grovevillage_topoda: ACTLocationData(rname.grove_village, 315, "Expired Grove - Village"), #2601baa3-999e-443b-ae33-ea619346413b-2_E-Cliffs
 
@@ -223,15 +225,15 @@ location_table: Dict[str, ACTLocationData] = {
     lname.breadclaw_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 608, "Flotsam Vale"), #669e8494-68f1-4de8-8814-6b41a0a69d18-2_A-HighSwamp
     lname.clothesclaw_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 610, "Flotsam Vale"), #b4a9c83a-b0c6-4606-a785-16f4ff33d66e-2_A-HighSwamp
     lname.hairclaw_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 614, "Flotsam Vale"), #6db7743b-1b30-49c4-983a-bb8256959022-2_A-HighSwamp
-    lname.chipclaw_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 615, "Flotsam Vale"), #70b7c84e-2c02-47c4-9e49-a58c78856f9d-2_C-Facilities
+    lname.chipclaw_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 615, "Flotsam Vale"), #adbf6e36-d142-458d-a2a4-3406168e3a12-2_C-Facilities
 
     lname.breadclaw_scuttleport_cubby: ACTLocationData(rname.scuttleport, 424, "Scuttleport"), #b5875ab1-4e89-4ba5-a9ea-6eca950d51f0-2_A-HighSwamp
     lname.clothesclaw_scuttleport_cubby: ACTLocationData(rname.scuttleport, 425, "Scuttleport"), #8f06cd49-3b2b-4883-b7a5-a421b38870ba-2_A-HighSwamp
     lname.hairclaw_scuttleport_cubbies: ACTLocationData(rname.scuttleport, 426, "Scuttleport"), #5c795be7-e38a-4986-bcfb-b72ea7e98787-2_A-HighSwamp
-    lname.breadclaw_scuttleport_grate: ACTLocationData(rname.scuttleport, 431, "Scuttleport"), #b2821ac0-6087-46a8-9809-61e20afb3a6e-2_C-Facilities
+    lname.breadclaw_scuttleport_grate: ACTLocationData(rname.scuttleport, 431, "Scuttleport"), #e5906936-1a8c-4f6e-8280-1be9d7f6f403-2_C-Facilities
     lname.hairclaw_scuttleport_magnet: ACTLocationData(rname.scuttleport, 435, "Scuttleport"), #62ab5a16-8e1f-411b-91d9-c71b45cd449e-2_C-Facilities
     lname.clothesclaw_scuttleport_electriccrab: ACTLocationData(rname.scuttleport, 436, "Scuttleport"), #12994a0d-c89b-4780-aaa9-48bf996c9348-2_C-Facilities
-    lname.clothesclaw_scuttleport_trashisland: ACTLocationData(rname.scuttleport, 446, "Scuttleport"), #6837a37b-eb98-42da-bd99-b589a7bc15a2-2_C-Facilities
+    lname.clothesclaw_scuttleport_trashisland: ACTLocationData(rname.scuttleport, 446, "Scuttleport"), #28baa847-9008-40e5-89b7-566612ca75f5-2_C-Facilities
     lname.paperclaw_scuttleport_elevator: ACTLocationData(rname.scuttleport, 447, "Scuttleport"), #c2d88bae-4763-4c16-b79e-802f00a519a7-2_C-Facilities
     lname.hairclaw_scuttleport_rooftopedge: ACTLocationData(rname.scuttleport, 449, "Scuttleport"), #bb733ac9-8027-47b6-bea5-f2f66e202da3-2_C-Facilities
     lname.hairclaw_scuttleport_rooftoptrash: ACTLocationData(rname.scuttleport, 450, "Scuttleport"), #d6b71350-5bc1-4b39-a53c-9ff5b93faf2b-2_C-Facilities
@@ -270,17 +272,20 @@ location_table: Dict[str, ACTLocationData] = {
     lname.hairclaw_plains_entrance: ACTLocationData(rname.plains, 522, "Abyssal Plains"), #f045426f-2bb7-43d7-8ae9-45d5bd73b3a2-2_D-SilentFlats
     lname.hairclaw_plains_shortcut: ACTLocationData(rname.plains, 524, "Abyssal Plains"), #3c128651-7160-4ff8-9aaa-20f4fe9fa6ef-2_D-SilentFlats
     lname.stapleclaw_plains_fish: ACTLocationData(rname.plains, 537, "Abyssal Plains"), #0fd36d2d-dbac-4284-b471-918f407d09aa-2_D-SilentFlats
+    lname.stapleclaw_unfathom_centreclam: ACTLocationData(rname.plains, 618, "Abyssal Plains"), #7b97c71e-bc63-4156-8077-851252c7383e-2_B-DarkCanyon
 
-    lname.paperclaw_oldocean_northhouse: ACTLocationData(rname.old_ocean, 538, "The Old Ocean"), #bb24e13b-1c43-4def-8d89-a997fb53772e-2_A-BleachedCopse
-    lname.hairclaw_oldocean_northhouse: ACTLocationData(rname.old_ocean, 539, "The Old Ocean"), #47f18391-b63c-402e-8787-3cebb4c72224-2_A-BleachedCopse
-    lname.paperclaw_oldocean_mainshortcut: ACTLocationData(rname.old_ocean, 540, "The Old Ocean"), #9248df82-ada8-4cd0-a839-3dcfa0443400-2_A-BleachedCopse
-    lname.paperclaw_oldocean_islandhouse: ACTLocationData(rname.old_ocean, 543, "The Old Ocean"), #db6e270b-224f-4bd9-9190-f27c522df224-2_A-BleachedCopse
-    lname.clothesclaw_oldocean_bubbles: ACTLocationData(rname.old_ocean, 546, "The Old Ocean"), #9fea96c3-97f8-4670-a5c5-fd2bf05aed14-2_A-BleachedCopse
-    lname.paperclaw_oldocean_shortcut: ACTLocationData(rname.old_ocean, 547, "The Old Ocean"), #8af465e9-b1df-49fe-a7fc-cfe9eede0e93-2_A-BleachedCopse
-    lname.hairclaw_oldocean_shortcut: ACTLocationData(rname.old_ocean, 548, "The Old Ocean"), #9d251937-c0f2-44b4-8247-a80ca0335d8d-2_A-BleachedCopse
-    lname.paperclaw_oldocean_southhouse: ACTLocationData(rname.old_ocean, 549, "The Old Ocean"), #0cde8fb4-1c06-4c31-ba70-dfd1906404a0-2_A-BleachedCopse
-    lname.carclaw_oldocean_islandclam: ACTLocationData(rname.old_ocean, 553, "The Old Ocean"), #584108d6-147a-4c89-9b42-53eb66c7d779-2_A-BleachedCopse
-    lname.stapleclaw_oldocean_brokenbridge: ACTLocationData(rname.old_ocean, 555, "The Old Ocean"), #a612eb7f-28ff-47a7-9576-8e15f3404802-2_A-BleachedCopse
+    lname.paperclaw_oldocean_northhouse: ACTLocationData(rname.old_ocean, 538, "The Old Ocean"), #451aaccb-f207-46fb-a1e0-87005f600a1d-2_A-BleachedCopse
+    lname.hairclaw_oldocean_northhouse: ACTLocationData(rname.old_ocean, 539, "The Old Ocean"), #765182cb-9f6e-440c-8c71-b03fe998ea0e-2_A-BleachedCopse
+    lname.paperclaw_oldocean_mainshortcut: ACTLocationData(rname.old_ocean, 540, "The Old Ocean"), #a003f790-11cb-4419-ac30-ec447187a2d0-2_A-BleachedCopse
+    lname.paperclaw_oldocean_islandhouse: ACTLocationData(rname.old_ocean, 543, "The Old Ocean"), #29006be3-6d62-41f8-82aa-e44c906fcfa9-2_A-BleachedCopse
+    lname.clothesclaw_oldocean_bubbles: ACTLocationData(rname.old_ocean, 546, "The Old Ocean"), #2a05d9c1-b7e2-4e2a-87b1-dac4ed775b8e-2_A-BleachedCopse
+    lname.paperclaw_oldocean_shortcut: ACTLocationData(rname.old_ocean, 547, "The Old Ocean"), #db268ee6-76ac-4537-9c02-1996c291ff10-2_A-BleachedCopse
+    lname.hairclaw_oldocean_shortcut: ACTLocationData(rname.old_ocean, 548, "The Old Ocean"), #12b952dd-aee3-4fec-b128-04636cf935a6-2_A-BleachedCopse
+    lname.paperclaw_oldocean_southhouse: ACTLocationData(rname.old_ocean, 549, "The Old Ocean"), #dd859464-428d-44f7-a81f-a85ac671fe6f-2_A-BleachedCopse
+    lname.carclaw_oldocean_islandclam: ACTLocationData(rname.old_ocean, 553, "The Old Ocean"), #560a19c0-374c-4c50-8ebf-ceaf556ac7b7-2_A-BleachedCopse
+    lname.stapleclaw_oldocean_brokenbridge: ACTLocationData(rname.old_ocean, 555, "The Old Ocean"), #e3c6fc65-0df9-4cba-98e2-14c698aa7a78-2_A-BleachedCopse
+    lname.paperclaw_oldocean_upperhouse: ACTLocationData(rname.old_ocean,624, "The Old Ocean"),
+    #1a2f542b-c84a-45d2-9c5d-192bf49123b3-2_A-BleachedCopse
     lname.paperclaw_oldocean_scourcrab: ACTLocationData(rname.old_ocean, 558, "The Old Ocean"), #216137c4-ed27-4bc7-89fd-0818f0b5ce89-2_B-GrandCourtyard
     lname.hairclaw_oldocean_northentrance: ACTLocationData(rname.old_ocean, 559, "The Old Ocean"), #e9e60f3d-0c0f-4481-ad22-827a32d9987e-2_B-GrandCourtyard
     lname.hairclaw_oldocean_cityentrance: ACTLocationData(rname.old_ocean, 560, "The Old Ocean"), #674cd75e-e914-4d6d-9bc3-9ead6219f833-2_B-GrandCourtyard
@@ -334,11 +339,11 @@ location_table: Dict[str, ACTLocationData] = {
     lname.oldworldwhorl_ridge_ncliff: ACTLocationData(rname.secluded_ridge, 190, "The Sands Between - Secluded Ridge"), #8e381b9e-ab7a-44ad-81c3-19157c97e0c6-2_A-OOGroveRadius
     lname.oldworldwhorl_ridge_eelclam: ACTLocationData(rname.secluded_ridge_eel, 205, "The Sands Between - Secluded Ridge Eelectrocute"), #80e66e11-8e9a-4896-9db1-f8cd4a25fefc-2_A-OOGroveRadius
 
-    lname.oldworldwhorl_grovemain_southclam: ACTLocationData(rname.grove_main, 217, "Expired Grove - Main"), #09b60c18-2172-41bb-9588-a3e764559b15-2_B-GroveForestHigh
-    lname.bloodstar_grovemain_waterfall: ACTLocationData(rname.grove_main, 229, "Expired Grove - Main"), #f1d3eafe-c252-4768-abcd-7f459e734d35-2_A-GroveForestLow
-    lname.kelpsprout_grovemain_carts: ACTLocationData(rname.grove_main, 261, "Expired Grove - Main"), #7069eee2-4c77-4a80-a276-1131e6cfe4b8-2_A-GroveForestLow
+    lname.oldworldwhorl_grovemain_southclam: ACTLocationData(rname.grove_main, 217, "Expired Grove - Main"), #e8b4805a-d793-4cd6-943e-bb51b0a6a7dd-2_A-GroveForestLow
+    lname.bloodstar_grovemain_waterfall: ACTLocationData(rname.grove_main, 229, "Expired Grove - Main"), #5053f259-8f89-44b2-a64e-6ad48884e569-2_A-GroveForestLow
+    lname.kelpsprout_grovemain_carts: ACTLocationData(rname.grove_main, 261, "Expired Grove - Main"), #7689fa51-f5c8-498f-a842-b302b47f806b-2_A-GroveForestLow
 
-    lname.bloodstar_grovevillage_carton: ACTLocationData(rname.grove_village, 295, "Expired Grove - Village"), #e9f1284d-a5cf-441e-a358-8cabf5e3a7b1-2_C-Village
+    lname.bloodstar_grovevillage_carton: ACTLocationData(rname.grove_village, 295, "Expired Grove - Village"), #ef8017ce-dab2-48d4-864a-7a53ea9a26a7-2_C-Village
     lname.tacklepouch_grovevillage_clam: ACTLocationData(rname.grove_village, 298, "Expired Grove - Village"), #c69ffc64-04af-44d1-b470-a867c5f06199-2_D-Caves
     lname.stainlessrelic_grovevillage_clam: ACTLocationData(rname.grove_village, 307, "Expired Grove - Village"), #269526ef-6bb0-42cf-a93d-e2cac970e424-2_E-Cliffs
     lname.oldworldwhorl_grovevillage_topoda: ACTLocationData(rname.grove_village, 316, "Expired Grove - Village"), #8b9b3b77-b95f-46a2-adfd-ca962e8f0cef-2_E-Cliffs
@@ -346,7 +351,7 @@ location_table: Dict[str, ACTLocationData] = {
     lname.bloodstar_flotsamvale_submerged: ACTLocationData(rname.flotsam_vale, 344, "Flotsam Vale"), #45cca266-a175-4020-9dd7-e0b844421aff-2_B-LowSwamp
     lname.oldworldwhorl_flotsamvale_cavepath: ACTLocationData(rname.flotsam_vale, 354, "Flotsam Vale"), #53cea11a-cfb6-4894-8e18-375ea895caed-2_A-HighSwamp
     lname.oldworldwhorl_flotsamvale_snail: ACTLocationData(rname.flotsam_vale, 357, "Flotsam Vale"), #32f43e6e-a382-4938-b068-f1eab35a0269-2_A-HighSwamp
-    lname.bloodstar_flotsamvale_craneclam: ACTLocationData(rname.post_ceviche, 397, "Flotsam Vale - Post Ceviche Sisters"), #977f86dc-aeb1-471f-bb86-4db41bcbfc2c-2_A-HighSwamp
+    lname.bloodstar_flotsamvale_craneclam: ACTLocationData(rname.post_ceviche, 397, "Flotsam Vale - Post Ceviche Sisters"), #bb7a792d-9933-49ce-93d0-6bf2762cdb69-2_A-HighSwamp
     lname.tacklepouch_flotsamvale_waterfall: ACTLocationData(rname.flotsam_vale, 403, "Flotsam Vale"), #b6c01d3a-31e3-457d-b53f-ecf0ff3b7e9f-2_B-LowSwamp
 
     lname.stainlessrelic_scuttleport_clam: ACTLocationData(rname.scuttleport, 438, "Scuttleport"), #95c7f334-5083-4ee8-bbcb-65033ca154f5-2_C-Facilities
@@ -365,8 +370,8 @@ location_table: Dict[str, ACTLocationData] = {
     lname.kelpsprout_plains_grappleclam: ACTLocationData(rname.plains, 535, "Abyssal Plains"), #2cb43e11-10dd-49af-8c42-f43ae2742bce-2_C-HermitCave
     lname.tacklepouch_plains_grapplesnail: ACTLocationData(rname.plains, 536, "Abyssal Plains"), #dac6390a-11b4-411e-9c6e-a406ef5ae503-2_D-SilentFlats
 
-    lname.oldworldwhorl_oldocean_ledgeclam: ACTLocationData(rname.old_ocean, 541, "The Old Ocean"), #f1d07afa-7684-4c41-ba1b-e3563cee1302-2_A-BleachedCopse
-    lname.bloodstar_oldocean_brokenbridge: ACTLocationData(rname.old_ocean, 556, "The Old Ocean"), #8a4445f5-aaa4-4f73-9aec-adffed944b03-2_A-BleachedCopse
+    lname.oldworldwhorl_oldocean_ledgeclam: ACTLocationData(rname.old_ocean, 541, "The Old Ocean"), #66709053-4a7a-4501-9473-f99bc9a250c0-2_A-BleachedCopse
+    lname.bloodstar_oldocean_brokenbridge: ACTLocationData(rname.old_ocean, 556, "The Old Ocean"), #d1befb56-8d22-4088-8eb2-a75fb79d112d-2_A-BleachedCopse
     lname.bloodstar_oldocean_citygates: ACTLocationData(rname.old_ocean, 568, "The Old Ocean"), #76bb55d0-f301-42d2-8933-28613fa84d2f-2_B-GrandCourtyard
     lname.stainlessrelic_oldocean_citywall: ACTLocationData(rname.old_ocean, 572, "The Old Ocean"), #081787e6-513e-4428-847d-618a5a4323dc-2_B-GrandCourtyard
     lname.kelpsprout_oldocean_parkourclam: ACTLocationData(rname.old_ocean, 576, "The Old Ocean"), #1705f88a-fcd1-4229-928f-61f0e4aca852-2_B-GrandCourtyard
@@ -409,42 +414,49 @@ location_table: Dict[str, ACTLocationData] = {
 
     lname.barbedhook_trashbin_eelgrapple: ACTLocationData(rname.trashbin_plateau, 210, "The Sands Between - Trashbin Plateau"), #2bccca10-1f27-4762-9a9b-8e628586e0a4-2_A-OOGroveRadius
 
-    lname.barbedhook_grovemain_sniper: ACTLocationData(rname.secluded_ridge, 214, "Expired Grove - Main"), #8fd70034-2415-4934-975b-2303d159f567-2_A-GroveForestLow
-    lname.barbedhook_grovemain_riverledge: ACTLocationData(rname.secluded_ridge, 215, "Expired Grove - Main"), #0860891c-3db6-4e51-8c0b-58b09ac8ece0-2_A-GroveForestLow
-    lname.barbedhook_grovemain_riversand: ACTLocationData(rname.secluded_ridge, 216, "Expired Grove - Main"), #2465aea2-9800-49e5-9e7e-d751ca2b3612-2_A-GroveForestLow
-    lname.barbedhook_grovemain_lichenthrope: ACTLocationData(rname.secluded_ridge, 221, "Expired Grove - Main"), #35455018-8cf6-48db-ba76-4ffbca84b0a8-2_A-GroveForestLow
-    lname.barbedhook_grovemain_lichenthropeeast: ACTLocationData(rname.secluded_ridge, 222, "Expired Grove  - Main"), #5a106f4d-8139-44da-9cdf-8d0bd70c6bf3-2_A-GroveForestLow
-    lname.barbedhook_grovemain_sodacans: ACTLocationData(rname.secluded_ridge, 223, "Expired Grove - Main"), #10a99891-923e-4bab-8057-b6d5781cb35d-2_A-GroveForestLow
-    lname.barbedhook_grovemain_acrossriver: ACTLocationData(rname.secluded_ridge, 228, "Expired Grove - Main"), #50f9f7d1-0e70-4333-b8b3-fbc46f04f3ea-2_A-GroveForestLow
-    lname.barbedhook_grovemain_afternets: ACTLocationData(rname.secluded_ridge, 230, "Expired Grove - Main"), #e7382e22-3232-4380-a734-bef8eb9a2a76-2_A-GroveForestLow
+    lname.barbedhook_grovemain_sniper: ACTLocationData(rname.secluded_ridge, 214, "Expired Grove - Main"), #1a0f7d65-c345-4ab2-b447-9a33d5f3acca-2_A-GroveForestLow
+    lname.barbedhook_grovemain_riverledge: ACTLocationData(rname.secluded_ridge, 215, "Expired Grove - Main"), #84480f21-e1d7-46d2-9c43-9669ed805a22-2_A-GroveForestLow
+    lname.barbedhook_grovemain_riversand: ACTLocationData(rname.secluded_ridge, 216, "Expired Grove - Main"), #9b359e06-c812-437d-b03b-175dd8ef77de-2_A-GroveForestLow
+    lname.barbedhook_grovemain_lichenthrope: ACTLocationData(rname.secluded_ridge, 221, "Expired Grove - Main"), #7f4c117f-b387-42cc-a689-8ace39284f5d-2_A-GroveForestLow
+    lname.barbedhook_grovemain_lichenthropeeast: ACTLocationData(rname.secluded_ridge, 222, "Expired Grove  - Main"), #dc6c6660-a95a-4587-85cd-cb012292d260-2_A-GroveForestLoww
+    lname.barbedhook_grovemain_sodacans: ACTLocationData(rname.secluded_ridge, 223, "Expired Grove - Main"), #80a22472-1b49-42d0-8ad5-a38ce1c7be8c-2_A-GroveForestLow
+    lname.barbedhook_grovemain_acrossriver: ACTLocationData(rname.secluded_ridge, 228, "Expired Grove - Main"), #c662e7b9-1f80-4a66-ae70-e0ba31f14a37-2_A-GroveForestLow
+    
     lname.barbedhook_grovemain_cartledge: ACTLocationData(rname.secluded_ridge, 235, "Expired Grove - Main"), #dc13eb69-ac98-4de9-9fe0-7f16a03d4ebb-2_A-GroveForestLow
     lname.barbedhook_grovemain_cartledgebottle: ACTLocationData(rname.secluded_ridge, 237, "Expired Grove - Main"), #a5b6f3f6-6e1c-4934-9006-26da6cee47f4-2_A-GroveForestLow
     lname.barbedhook_grovemain_paperplate: ACTLocationData(rname.secluded_ridge, 241, "Expired Grove - Main"), #776881ba-f61b-4400-8cf5-f11fb11b6f94-2_B-GroveForestHigh
     lname.barbedhook_grovemain_oildrum: ACTLocationData(rname.secluded_ridge, 242, "Expired Grove - Main"), #12c73a88-beef-4bfb-a2d1-c159c91d8304-2_B-GroveForestHigh
-    lname.barbedhook_grovemain_canopy: ACTLocationData(rname.grove_raised_platforms, 248, "Expired Grove - Raised Platforms"), #101eff6d-e09a-471d-86fd-cdc587012c32-2_A-GroveForestLow
+    lname.barbedhook_grovemain_canopy: ACTLocationData(rname.grove_raised_platforms, 248, "Expired Grove - Raised Platforms"), #75b98171-82f1-4559-ac2a-d0a63cccfab2-2_A-GroveForestLow
     lname.barbedhook_grovemain_drumtop: ACTLocationData(rname.secluded_ridge, 250, "Expired Grove - Main"), #3a1e7a2c-5111-4360-b168-cc5e84088b6a-2_B-GroveForestHigh
-    lname.barbedhook_grovemain_carts: ACTLocationData(rname.grove_main, 259, "Expired Grove - Main"), #d1b73602-aca6-4d33-991d-39110a5e6780-2_A-GroveForestLow
-    lname.sharkegg_grovemain_mantis: ACTLocationData(rname.grove_main, 260, "Expired Grove - Main"), #f734eb5e-d674-4c84-9493-61d20f70fde3-2_A-GroveForestLow
+    lname.barbedhook_grovemain_carts: ACTLocationData(rname.grove_main, 259, "Expired Grove - Main"), #bfe46822-3646-4b65-872d-718ab758ab6c-2_A-GroveForestLow
+    lname.sharkegg_grovemain_mantis: ACTLocationData(rname.grove_main, 260, "Expired Grove - Main"), #1bace4e0-6ae9-4c89-a583-3d2a9dab800e-2_A-GroveForestLow
+    lname.barbedhook_grovemain_entranceparkour: ACTLocationData(rname.grove_main, 620, "Expired Grove - Main"),
+    #9a2f64f8-cba8-41a4-acac-8cc3e6e9583d-2_A-GroveForestLow
+    lname.barbedhook_grovemain_platebottle: ACTLocationData(rname.grove_main, 622, "Expired Grove - Main"),
+    #6440b99a-9998-4191-961a-32d9f1ecd9e4-2_A-GroveForestLow
+    lname.barbedhook_grovemain_cartledgebottle2: ACTLocationData(rname.grove_main, 623, "Expired Grove - Main"),
+    #f446f24d-71ec-4f13-a6a0-ad5834080de6-2_A-GroveForestLow
+    lname.barbedhook_grovemain_smallhall: ACTLocationData(rname.grove_main, 231, "Expired Grove - Main"), #cf1311a6-d64c-4d03-b32e-f6440bb9e247-2_A-GroveForestLow
 
     lname.barbedhook_grovevillage_heikea: ACTLocationData(rname.grove_village, 287, "Expired Grove - Village"), #bcfabbd4-8575-4a6a-8325-7259996a7d68-2_D-Caves
     lname.barbedhook_grovevillage_cartfish: ACTLocationData(rname.grove_village, 271, "Expired Grove - Village"), #7a38fbf2-47a9-4bf6-85d1-f8d4f58b8d66-2_B-GroveForestHigh
     lname.barbedhook_grovevillage_riveroil: ACTLocationData(rname.grove_village, 273, "Expired Grove - Village"), #9c983d04-ac83-40f0-8220-d92f76ea7099-2_B-GroveForestHigh
-    lname.barbedhook_grovevillage_bottles: ACTLocationData(rname.grove_village, 275, "Expired Grove - Village"), #5c973136-cfe9-4ea5-bc93-60ffa4b5cc13-2_C-Village
-    lname.barbedhook_grovevillage_crabs: ACTLocationData(rname.grove_village, 277, "Expired Grove - Village"), #4721ab20-67be-4d5b-b0bb-3f2c2ecb510f-2_C-Village
-    lname.barbedhook_grovevillage_centercarton: ACTLocationData(rname.grove_village, 278, "Expired Grove - Village"), #bae2eb9a-56a0-4548-8c6d-798d234ba479-2_C-Village
-    lname.barbedhook_grovevillage_corpse: ACTLocationData(rname.grove_village, 279, "Expired Grove - Village"), #20238db7-8d1e-4045-8e0a-de2aaea1cb49-2_C-Village
-    lname.barbedhook_grovevillage_path: ACTLocationData(rname.grove_village, 280, "Expired Grove - Village"), #87e729ae-0659-4b6e-9ac1-c1d059719ba8-2_C-Village
-    lname.barbedhook_grovevillage_Ncarton: ACTLocationData(rname.grove_village, 282, "Expired Grove - Village"), #b29402c2-62e8-4fa3-8c27-4e419750b16f-2_C-Village
-    lname.barbedhook_grovevillage_SWcarton: ACTLocationData(rname.grove_village, 284, "Expired Grove - Village"), #256daaaa-675c-47e5-bd4e-367dc4abd9e2-2_C-Village
-    lname.sharkegg_grovevillage_sniper: ACTLocationData(rname.grove_village, 285, "Expired Grove - Village"), #451f2fe5-9c29-4710-9493-0878963547e4-2_C-Village
+    lname.barbedhook_grovevillage_bottles: ACTLocationData(rname.grove_village, 275, "Expired Grove - Village"), #0cf8ca63-6a57-411d-92d5-b476c1446e9b-2_C-Village
+    lname.barbedhook_grovevillage_crabs: ACTLocationData(rname.grove_village, 277, "Expired Grove - Village"), #9614ea8c-152a-4aea-96df-697628c6d639-2_C-Village
+    lname.barbedhook_grovevillage_centercarton: ACTLocationData(rname.grove_village, 278, "Expired Grove - Village"), #d55b82a8-3eb1-4d71-9cc7-75dc837924a9-2_C-Village
+    lname.barbedhook_grovevillage_corpse: ACTLocationData(rname.grove_village, 279, "Expired Grove - Village"), #a587f40e-b255-4fb5-a1ee-863082e603a4-2_C-Village
+    lname.barbedhook_grovevillage_path: ACTLocationData(rname.grove_village, 280, "Expired Grove - Village"), #655d7880-1c82-441f-9929-807cd45187a3-2_C-Village
+    lname.barbedhook_grovevillage_Ncarton: ACTLocationData(rname.grove_village, 282, "Expired Grove - Village"), #18b63b27-1174-4759-a11f-0a50ef5758e4-2_C-Village
+    lname.barbedhook_grovevillage_SWcarton: ACTLocationData(rname.grove_village, 284, "Expired Grove - Village"), #a73325d0-5e3f-49bf-8f45-4c2466073010-2_C-Village
+    lname.sharkegg_grovevillage_sniper: ACTLocationData(rname.grove_village, 285, "Expired Grove - Village"), #db0d1b3f-21fe-4d48-85d0-54d250bfa8a0-2_C-Village
     lname.barbedhook_grovevillage_boat: ACTLocationData(rname.grove_village, 286, "Expired Grove - Village"), #99c33625-2da4-4f69-a0af-8a8d2da3b399-2_D-Caves
     lname.barbedhook_grovevillage_butter: ACTLocationData(rname.grove_village, 290, "Expired Grove - Village"), #10eae42f-9cca-447a-8cb8-9cffcba11ecd-2_D-Caves
-    lname.barbedhook_grovevillage_above1: ACTLocationData(rname.grove_village, 301, "Expired Grove - Village"), #28362ae0-defe-4a04-b449-93d7e5e60676-2_C-Village
+    lname.barbedhook_grovevillage_above1: ACTLocationData(rname.grove_village, 301, "Expired Grove - Village"), #b571bdc4-1f34-476e-a4f3-149858da1108-2_C-Village
     lname.barbedhook_grovevillage_above2: ACTLocationData(rname.grove_village, 302, "Expired Grove - Village"), #0177d8ef-8849-4ea4-b1b3-08a1c3134a99-2_E-Cliffs
     lname.barbedhook_grovevillage_above3: ACTLocationData(rname.grove_village, 303, "Expired Grove - Village"), #b3a776e1-52ab-4dc8-adc1-55c95eca9972-2_E-Cliffs
     lname.barbedhook_grovevillage_ornament: ACTLocationData(rname.grove_village, 304, "Expired Grove - Village"), #ce1700e2-d9d0-462a-af23-cb55828b062a-2_E-Cliffs
     lname.barbedhook_grovevillage_hammer: ACTLocationData(rname.grove_village, 305, "Expired Grove - Village"), #235b691b-0f18-4f35-bd8a-7536e12fabfe-2_E-Cliffs
-    lname.barbedhook_grovevillage_dock: ACTLocationData(rname.grove_village, 309, "Expired Grove - Village"), #aff46c65-7a4a-4b1c-a0ca-840af3898f26-2_C-Village
+    lname.barbedhook_grovevillage_dock: ACTLocationData(rname.grove_village, 309, "Expired Grove - Village"), #58571bb7-9503-48c7-a212-01c06bb77296-2_C-Village
 
     lname.barbedhook_flotsamvale_entranceledge: ACTLocationData(rname.flotsam_vale, 338, "Flotsam Vale"), #17ac32ac-f0fc-4613-9e02-5ffdf4eecb63-2_B-LowSwamp
     lname.barbedhook_flotsamvale_entrancerocks: ACTLocationData(rname.flotsam_vale, 339, "Flotsam Vale"), #7aa4931c-e44f-4531-9b5e-eb1a01418fdd-2_B-LowSwamp
@@ -466,15 +478,15 @@ location_table: Dict[str, ACTLocationData] = {
     lname.barbedhook_flotsamvale_consortium: ACTLocationData(rname.consortium_arena, 408, "Flotsam Vale - Consortium Arena"), #b81ed4dc-3b3e-420d-99e9-d676c88fc120-2_B-LowSwamp
     lname.barbedhook_flotsamvale_snailfish: ACTLocationData(rname.flotsam_vale, 413, "Flotsam Vale"), #cdf2769f-deb3-43dc-841f-a4c1c0081833-2_A-HighSwamp
     lname.barbedhook_flotsamvale_westfish: ACTLocationData(rname.flotsam_vale, 420, "Flotsam Vale"), #698a076c-2661-4731-90c4-211d8b1414c6-2_A-HighSwamp
-    lname.barbedhook_flotsamvale_behindcubby: ACTLocationData(rname.flotsam_vale, 605, "Flotsam Vale"), #5b786881-414b-41d4-97ea-b3a850d3633a-2_A-HighSwamp
     lname.barbedhook_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 611, "Flotsam Vale"), #3b49cdc6-b609-49b0-a1c2-57307a398920-2_A-HighSwamp
     lname.barbedhook_flotsamvale_sludgefish: ACTLocationData(rname.flotsam_vale, 612, "Flotsam Vale"), #a6a69a65-21fa-4bdd-8940-e1f1f6c226a0-2_A-HighSwamp
 
+    lname.barbedhook_flotsamvale_behindcubby: ACTLocationData(rname.scuttleport, 605, "Scuttleport"), #5b786881-414b-41d4-97ea-b3a850d3633a-2_A-HighSwamp
     lname.barbedhook_scuttleport_cubby: ACTLocationData(rname.scuttleport, 429, "Scuttleport"), #a91e708c-89a8-4ef0-bf21-870cd56e652e-2_A-HighSwamp
-    lname.barbedhook_scuttleport_magnet: ACTLocationData(rname.scuttleport, 434, "Scuttleport"), #f738e9de-5eb9-41c1-8358-48a6d51a9fff-2_C-Facilities
+    lname.barbedhook_scuttleport_magnet: ACTLocationData(rname.scuttleport, 434, "Scuttleport"), #6b8cd4a1-7a84-4148-837a-75369a25511d-2_C-Facilities
     lname.barbedhook_scuttleport_sorting: ACTLocationData(rname.scuttleport, 439, "Scuttleport"), #5eefb844-f267-416a-ba6e-c1b8ec945cfa-2_C-Facilities
     lname.barbedhook_scuttleport_magnetdropoff1: ACTLocationData(rname.scuttleport, 442, "Scuttleport"), #631f983b-ebc5-4fa3-aedc-38fd4d1efffb-2_C-Facilities
-    lname.barbedhook_scuttleport_trashisland: ACTLocationData(rname.scuttleport, 445, "Scuttleport"), #497aa1a9-1ffa-4ea1-ad17-32fa6654db2e-2_C-Facilities
+    lname.barbedhook_scuttleport_trashisland: ACTLocationData(rname.scuttleport, 445, "Scuttleport"), #931eb344-1b24-4995-947b-4e56674151a5-2_C-Facilities
     lname.barbedhook_scuttleport_magnetdropoff2: ACTLocationData(rname.scuttleport, 448, "Scuttleport"), #e449f43b-dc05-4e13-8f8c-b93adf0e97fa-2_C-Facilities
     lname.barbedhook_scuttleport_trashblock: ACTLocationData(rname.scuttleport, 453, "Scuttleport"), #de7097a4-7028-454b-98e6-c61a03557736-2_C-Facilities
     lname.barbedhook_scuttleport_magrail1: ACTLocationData(rname.scuttleport, 459, "Scuttleport"), #301e305f-fc4c-4bd5-a839-ca1ea6435c13-2_C-Facilities
@@ -492,11 +504,11 @@ location_table: Dict[str, ACTLocationData] = {
     lname.barbedhook_unfathom_mimic: ACTLocationData(rname.unfathom, 492, "The Unfathom"), #98535001-699c-4e64-a07d-74e610f04528-2_B-DarkCanyon
     lname.barbedhook_unfathom_mimichill: ACTLocationData(rname.unfathom, 493, "The Unfathom"), #54a8f869-ff96-45b2-93de-fb1eeeec313f-2_B-DarkCanyon
 
-    lname.barbedhook_oldocean_northwesthouse: ACTLocationData(rname.old_ocean, 542, "The Old Ocean"), #14d445d2-f997-458d-a285-123bf009c223-2_A-BleachedCopse
-    lname.barbedhook_oldocean_southhouse: ACTLocationData(rname.old_ocean, 550, "The Old Ocean"), #c9b315b7-28de-4efb-9d0c-608e9629a9a7-2_A-BleachedCopse
-    lname.barbedhook_oldocean_secondisland: ACTLocationData(rname.old_ocean, 552, "The Old Ocean"), #2e322c37-6011-41eb-ac2b-7fb67d0d85b1-2_A-BleachedCopse
-    lname.barbedhook_oldocean_brokenbridge1: ACTLocationData(rname.old_ocean, 554, "The Old Ocean"), #765f4cdd-d7a5-4954-be69-99ed7c68913b-2_A-BleachedCopse
-    lname.barbedhook_oldocean_brokenbridge2: ACTLocationData(rname.old_ocean, 557, "The Old Ocean"), #6a75e525-e399-482b-b21f-42ae8ae63a17-2_A-BleachedCopse
+    lname.barbedhook_oldocean_northwesthouse: ACTLocationData(rname.old_ocean, 542, "The Old Ocean"), #9da554ca-25f7-4f4f-a914-0276899663cc-2_A-BleachedCopse
+    lname.barbedhook_oldocean_southhouse: ACTLocationData(rname.old_ocean, 550, "The Old Ocean"), #e83d3323-c371-4358-bd76-372285b083ba-2_A-BleachedCopse
+    lname.barbedhook_oldocean_secondisland: ACTLocationData(rname.old_ocean, 552, "The Old Ocean"), #0317b352-75a3-4ac5-8f23-f44c5170a5af-2_A-BleachedCopse
+    lname.barbedhook_oldocean_brokenbridge1: ACTLocationData(rname.old_ocean, 554, "The Old Ocean"), #80dadb0e-6347-4c6d-b7e2-bbc8041bed96-2_A-BleachedCopse
+    lname.barbedhook_oldocean_brokenbridge2: ACTLocationData(rname.old_ocean, 557, "The Old Ocean"), #35c3ce0a-a17b-4ca1-b9b5-9b5c32b1a531-2_A-BleachedCopse
     lname.barbedhook_oldocean_entrance: ACTLocationData(rname.old_ocean, 564, "The Old Ocean"), #f94fbed4-a90c-46e8-a6a3-343f81728eba-2_B-GrandCourtyard
     lname.barbedhook_oldocean_citygates: ACTLocationData(rname.old_ocean, 565, "The Old Ocean"), #20dffb0a-e6b1-4c00-8f25-d66aefedcc22-2_B-GrandCourtyard
     lname.sharkegg_oldocean_citygates: ACTLocationData(rname.old_ocean, 570, "The Old Ocean"), #f8ef34b2-f3b7-44d6-84b6-63749adc075f-2_B-GrandCourtyard
@@ -578,26 +590,26 @@ location_table: Dict[str, ACTLocationData] = {
     lname.smallbattery_trashbin_mantis: ACTLocationData(rname.trashbin_plateau, 201, "The Sands Between - Trashbin Plateau"), #0d86fe0e-ae41-4fb2-beb2-9bb5e558429a-2_A-OOGroveRadius
     lname.googlyeye_trashbin_pineapple: ACTLocationData(rname.trashbin_plateau, 202, "The Sands Between - Trashbin Plateau"), #7935fe1e-318c-4f90-901b-fa001de6e4dc-2_A-OOGroveRadius
 
-    lname.barnacle_grovemain_colander: ACTLocationData(rname.grove_main, 213, "Expired Grove - Main"), #74aa4107-6a5a-4868-ae54-942e4421be3f-2_A-GroveForestLow
-    lname.seastar_grovemain_eastrock: ACTLocationData(rname.grove_main, 218, "Expired Grove - Main"), #17cb1eed-8d88-4464-b33b-215c837035f6-2_A-GroveForestLow
-    lname.pufferquill_grovemain_sponges: ACTLocationData(rname.grove_main, 220, "Expired Grove - Main"), #c6a56f3d-c134-41cd-83b7-4a755fa32284-2_A-GroveForestLow
-    lname.limpet_grovemain_sodacan: ACTLocationData(rname.grove_main, 236, "Expired Grove - Main"), #093c4972-ff5e-4ba6-b9a8-136411e1017f-2_A-GroveForestLow
-    lname.lumpsucker_grovemain_canopy: ACTLocationData(rname.grove_raised_platforms, 247, "Expired Grove - Raised Platforms"), #3789e56d-69b5-4d6c-adb1-6454b101840d-2_A-GroveForestLow
+    lname.barnacle_grovemain_colander: ACTLocationData(rname.grove_main, 213, "Expired Grove - Main"), #09fbd30a-ce33-45a9-bffd-8b4f24c35559-2_A-GroveForestLow
+    lname.seastar_grovemain_eastrock: ACTLocationData(rname.grove_main, 218, "Expired Grove - Main"), #f429fad9-bbb8-4eaf-a154-80164a6550c3-2_A-GroveForestLow
+    lname.pufferquill_grovemain_sponges: ACTLocationData(rname.grove_main, 220, "Expired Grove - Main"), #36499157-9a63-42c2-b3b2-644546520db0-2_A-GroveForestLow
+    lname.limpet_grovemain_sodacan: ACTLocationData(rname.grove_main, 236, "Expired Grove - Main"), #0eed5053e-c3f5-4c95-868b-86d92ba3d9a1-2_A-GroveForestLow
+    lname.lumpsucker_grovemain_canopy: ACTLocationData(rname.grove_raised_platforms, 247, "Expired Grove - Raised Platforms"), #d1bd4b15-62ca-4363-94ec-59b9abbff10b-2_A-GroveForestLow
     lname.anothercrab_grovemain_sniper: ACTLocationData(rname.grove_main, 619, "Expired Grove - Main"), #8e4714bf-cc7f-4bde-9c88-7fcdbf8d0afe-2_A-GroveForestLow
     lname.sharktooth_grovemain_pizza: ACTLocationData(rname.grove_main, 251, "Expired Grove - Main"), #8e34f6a5-5844-4767-ab15-4fbaf6c147dc-2_B-GroveForestHigh
-    lname.contactlens_grovemain_carts: ACTLocationData(rname.grove_main, 262, "Expired Grove - Main"), #0e278f86-0f9d-468f-95b2-586df2a94689-2_A-GroveForestLow
+    lname.contactlens_grovemain_carts: ACTLocationData(rname.grove_main, 262, "Expired Grove - Main"), #ac0843c0-17cd-4af2-a11c-d1d42bd0ccea-2_A-GroveForestLow
     lname.cottonball_grovemain_mantis: ACTLocationData(rname.grove_main, 263, "Expired Grove - Main"), #fa3cfc64-4f87-452c-bf59-4f599cb3f6fa-2_A-GroveForestLow
-    lname.mussel_grovemain_fishing: ACTLocationData(rname.grove_main, 264, "Expired Grove - Main"), #a1c14883-bc09-441c-a188-20dabf047532-2_A-GroveForestLow
-    lname.sponge_grovemain_fishing: ACTLocationData(rname.grove_main, 265, "Expired Grove - Main"), #7aa1847-5a38-4f15-a6fc-90c15cd9baf7-2_A-GroveForestLow
-    lname.oyster_grovemain_fishing: ACTLocationData(rname.grove_main, 266, "Expired Grove - Main"), #6ce4acf2-09a4-43ca-9be7-5d79a9d5c781-2_A-GroveForestLow
-    lname.limpet_grovemain_fishing: ACTLocationData(rname.grove_main, 267, "Expired Grove - Main"), #027511ce-7f48-480e-91af-18b4c7aaa57d-2_A-GroveForestLow
+    lname.mussel_grovemain_fishing: ACTLocationData(rname.grove_main, 264, "Expired Grove - Main"), #96c16da5-97e3-44db-bca9-8a4990c2707b-2_A-GroveForestLow
+    lname.sponge_grovemain_fishing: ACTLocationData(rname.grove_main, 265, "Expired Grove - Main"), #a8310c1f-205c-42cf-bcbd-66b0636e8901-2_A-GroveForestLow
+    lname.oyster_grovemain_fishing: ACTLocationData(rname.grove_main, 266, "Expired Grove - Main"), #5480f8db-7801-4ca6-bbca-71dd0876785a-2_A-GroveForestLow
+    lname.limpet_grovemain_fishing: ACTLocationData(rname.grove_main, 267, "Expired Grove - Main"), #622cbc21-fcd5-44d1-8e95-c6fcaacc2dcb-2_A-GroveForestLow
 
     lname.anemone_grovevillage_fishing: ACTLocationData(rname.grove_village, 274, "Expired Grove - Village"), #5e81380f-3e8f-4d44-a0ef-ebbad0f23fdb-2_B-GroveForestHigh
-    lname.phytoplanktonplus_grovevillage_upsidedown: ACTLocationData(rname.grove_village, 300, "Expired Grove - Village"), #03bc01f8-4691-40b7-93c6-4d45563b5b46-2_C-Village
+    lname.phytoplanktonplus_grovevillage_upsidedown: ACTLocationData(rname.grove_village, 300, "Expired Grove - Village"), #5e1cd261-5882-4737-a524-e27b267b61b0-2_C-Village
     lname.wadofgum_grovevillage_gumpile: ACTLocationData(rname.grove_village, 306, "Expired Grove - Village"), #ab2ba852-edf4-467f-a1f5-1825341b7596-2_E-Cliffs
     lname.anemone_grovevillage_seahorse: ACTLocationData(rname.grove_village, 308, "Expired Grove - Village"), #32841813-148d-45f7-8c4e-4464f157200d-2_E-Cliffs
-    lname.mussel_grovevillage_dock: ACTLocationData(rname.grove_village, 310, "Expired Grove - Village"), #3f1f877c-e5ac-40d1-93b7-2245282b0669-2_C-Village
-    lname.earthworm_grovevillage_dock: ACTLocationData(rname.grove_village, 313, "Expired Grove - Village"), #725998d5-172d-4408-9f70-0f9264a6a6fd-2_C-Village
+    lname.mussel_grovevillage_dock: ACTLocationData(rname.grove_village, 310, "Expired Grove - Village"), #26a3a961-1a29-4d56-a5b3-5612b84d6241-2_C-Village
+    lname.earthworm_grovevillage_dock: ACTLocationData(rname.grove_village, 313, "Expired Grove - Village"), #70ae97d9-a424-4c98-85f4-150815ea3dd2-2_C-Village
 
     lname.anemone_flotsamvale_butaneisland: ACTLocationData(rname.flotsam_vale, 346, "Flotsam Vale"), #76b9b9ce-875c-4136-a6da-dabdfc70d40e-2_B-LowSwamp
     lname.rustynail_flotsamvale_brokenbutane: ACTLocationData(rname.flotsam_vale, 350, "Flotsam Vale"), #d656b2e6-15ec-4e24-bebb-94c1ed7f6c30-2_B-LowSwamp
@@ -605,7 +617,7 @@ location_table: Dict[str, ACTLocationData] = {
     lname.mussel_flotsamvale_woodplatform: ACTLocationData(rname.flotsam_vale, 363, "Flotsam Vale"), #e5b02de1-7cb7-4a4d-98a9-369c44302cac-2_A-HighSwamp
     lname.rustynail_flotsamvale_steamroller: ACTLocationData(rname.flotsam_vale, 367, "Flotsam Vale"), #f8d826c0-7319-4f95-ab90-bf28a7218dfb-2_A-HighSwamp
     lname.limpet_flotsamvale_trashpile: ACTLocationData(rname.flotsam_vale, 368, "Flotsam Vale"), #855a1efa-0f38-4e6b-a68d-24a991dcac42-2_A-HighSwamp
-    lname.barnacle_flotsamvale_steamroller: ACTLocationData(rname.post_ceviche, 607, "Flotsam Vale - Post Ceviche Sisters"), #TODO update index
+    lname.barnacle_flotsamvale_steamroller: ACTLocationData(rname.post_ceviche, 607, "Flotsam Vale - Post Ceviche Sisters"), 
     #9545c7d7-0ea6-457b-ad4d-c744984f0d79-2_A-HighSwamp
     lname.fruitsticker_flotsamvale_westbutane: ACTLocationData(rname.flotsam_vale, 371, "Flotsam Vale"), #0ad3895d-4612-4856-a6ed-7a7b48f2c36f-2_A-HighSwamp
     lname.seacucumber_flotsamvale_westbutane: ACTLocationData(rname.flotsam_vale, 372, "Flotsam Vale"), #5ccf4e25-ff98-4a9a-9e31-2eea57589809-2_A-HighSwamp
@@ -626,18 +638,18 @@ location_table: Dict[str, ACTLocationData] = {
     lname.anemoneplus_flotsamvale_northwestfish: ACTLocationData(rname.flotsam_vale, 421, "Flotsam Vale"), #f29c22d3-4459-4d21-b76d-dbdd514fe09a-2_A-HighSwamp
     lname.turtleshell_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 609, "Flotsam Vale"), #584ec079-5ecc-409b-bcac-7197b1d04a1c-2_A-HighSwamp
     lname.lilisopod_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 613, "Flotsam Vale"), #6709552a-af26-4b87-a69e-97830fd645be-2_A-HighSwamp
-    lname.rustynail_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 616, "Flotsam Vale"), #fa0535e3-55e1-4879-ac12-9327d5858b1a-2_C-Facilities
-    lname.barnacle_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 617, "Flotsam Vale"), #c376ad88-aa83-4923-9652-13fd98a67a19-2_C-Facilities
+    lname.rustynail_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 616, "Flotsam Vale"), #dbcacde0-7803-42c7-8894-026826e23a67-2_C-Facilities
+    lname.barnacle_flotsamvale_gunkfish: ACTLocationData(rname.flotsam_vale, 617, "Flotsam Vale"), #670ead0c-1985-4d91-a259-3ab2d5162376-2_C-Facilities
 
     lname.googlyeye_scuttleport_cubbies: ACTLocationData(rname.scuttleport, 427, "Scuttleport"), #5736e238-67d5-4215-823d-a0c3b3d60b2a-2_A-HighSwamp
     lname.seastar_scuttleport_cubbies: ACTLocationData(rname.scuttleport, 428, "Scuttleport"), #69c1d4c5-c467-4127-a12a-6277376c47f0-2_A-HighSwamp
-    lname.sanddollar_scuttleport_magnet: ACTLocationData(rname.scuttleport, 432, "Scuttleport"), #14992c5b-3377-4664-9309-3f44a31b1ae5-2_C-Facilities
-    lname.mussel_scuttleport_magnetfish: ACTLocationData(rname.scuttleport, 433, "Scuttleport"), #6c265bf5-d319-4a6b-8ddf-ad803b9bdde6-2_C-Facilities
+    lname.sanddollar_scuttleport_magnet: ACTLocationData(rname.scuttleport, 432, "Scuttleport"), #bfa268ed-5df9-410b-a71e-fc8f0f711655-2_C-Facilities
+    lname.mussel_scuttleport_magnetfish: ACTLocationData(rname.scuttleport, 433, "Scuttleport"), #3d0db077-a9de-4725-92ac-8c4cd24d3b73-2_C-Facilities
     lname.limpet_scuttleport_electricboxes: ACTLocationData(rname.scuttleport, 437, "Scuttleport"), #34e41971-5cef-4947-b6ff-6b1e4da0f2d6-2_C-Facilities
     lname.rubberband_scuttleport_magnetdropoff: ACTLocationData(rname.scuttleport, 440, "Scuttleport"), #f1ce3edd-314d-4cf7-ae79-fdb5cf0a7ac0-2_C-Facilities
     lname.limpet_scuttleport_magnet: ACTLocationData(rname.scuttleport, 441, "Scuttleport"), #1a376ec2-e1bf-44a3-bc18-0ec8d4252b0d-2_C-Facilities
     lname.anemoneplus_scuttleport_magnetdropoff: ACTLocationData(rname.scuttleport, 443, "Scuttleport"), #b0c6c00b-fcbb-4884-83c7-cf655211e599-2_C-Facilities
-    lname.lumpsucker_scuttleport_trashisland: ACTLocationData(rname.scuttleport, 444, "Scuttleport"), #555557dd-239a-40da-a89f-82d0cc6adc65-2_C-Facilities
+    lname.lumpsucker_scuttleport_trashisland: ACTLocationData(rname.scuttleport, 444, "Scuttleport"), #5c2d7cbb-1040-4e43-9aee-fac430ece31d-2_C-Facilities
     lname.sinkerplusplus_scuttleport_clam: ACTLocationData(rname.scuttleport, 451, "Scuttleport"), #f2466d53-7e70-4d19-9c12-cb9da07a72fe-2_C-Facilities
     lname.seastar_scuttleport_survivorcamp: ACTLocationData(rname.scuttleport, 455, "Scuttleport"), #17a5b692-c56b-4f43-8ca2-b2909ef9c446-2_C-Facilities
     lname.pufferquill_scuttleport_survivorcamp: ACTLocationData(rname.scuttleport, 456, "Scuttleport"), #08bbdb7b-63dd-4e3d-9499-fc77548c3bd9-2_C-Facilities
@@ -670,29 +682,31 @@ location_table: Dict[str, ACTLocationData] = {
     lname.seacucumber_plains_entrance: ACTLocationData(rname.plains, 531, "Abyssal Plains"), #82554ff8-c8f1-42b3-8018-f84f5ec94c55-2_D-SilentFlats
     lname.fruitsticker_plains_entrance: ACTLocationData(rname.plains, 533, "Abyssal Plains"), #fda1ad5d-5abb-4351-b682-8e91036ccddd-2_D-SilentFlats
 
-    lname.sanddollar_oldocean_ledge: ACTLocationData(rname.plains, 544, "The Old Ocean"), #5f0809f4-5a0f-4b4d-be76-1386bc665a16-2_A-BleachedCopse
-    lname.barnacleplusplus_oldocean_styrofoam: ACTLocationData(rname.plains, 545, "The Old Ocean"), #19a53c5e-497f-4e5e-a947-6a065747c92a-2_A-BleachedCopse
-    lname.seastarplusplus_oldocean_entranceclam: ACTLocationData(rname.plains, 561, "The Old Ocean"), #6df4f101-e0f2-4147-94e8-54235e8b803f-2_B-GrandCourtyard
-    lname.spongeplus_oldocean_entrance: ACTLocationData(rname.plains, 563, "The Old Ocean"), #9cd5413b-91c2-421a-92de-8a703922f888-2_B-GrandCourtyard
-    lname.sanddollar_oldocean_citywall: ACTLocationData(rname.plains, 571, "The Old Ocean"), #b27f8f08-2a6d-4f78-8ef5-ca01d2b968ef-2_B-GrandCourtyard
-    lname.usedbandageplus_oldocean_citywall: ACTLocationData(rname.plains, 579, "The Old Ocean"), #5988e9dd-dc40-4f00-af63-66da9db0e7b4-2_B-GrandCourtyard
-    lname.cockleplus_oldocean_snaileast: ACTLocationData(rname.plains, 582, "The Old Ocean"), #3e336fbb-9830-4772-a1b3-55dc039380dd-2_B-GrandCourtyard
-    lname.anothercrab_oldocean_elevator: ACTLocationData(rname.plains, 588, "The Old Ocean"), #b7757de2-ce70-474e-a332-cef609bdf42f-2_B-GrandCourtyard
-    lname.sanddollar_oldocean_easternbuilding: ACTLocationData(rname.plains, 592, "The Old Ocean"), #4babc398-17b9-4197-958e-c6bebc12a6c6-2_B-GrandCourtyard
-    lname.phytoplanktonplus_oldocean_clam: ACTLocationData(rname.plains, 600, "The Old Ocean"), #a9ac0a98-889e-4138-a62b-0d59f63af118-2_B-GrandCourtyard
-    lname.musselplusplus_oldocean_woodplank: ACTLocationData(rname.plains, 601, "The Old Ocean"), #df538a5c-9108-4210-8b9d-89e777116ec4-2_B-GrandCourtyard
-    lname.whelkplusplus_oldocean_mantis: ACTLocationData(rname.plains, 604, "The Old Ocean"), #21387127-4e04-4017-bb58-3aafb9537876-2_B-GrandCourtyard
+    lname.sanddollar_oldocean_ledge: ACTLocationData(rname.old_ocean, 544, "The Old Ocean"), #7b965ee1-f184-45d5-ac62-0dbc2c6800ac-2_A-BleachedCopse
+    lname.barnacleplusplus_oldocean_styrofoam: ACTLocationData(rname.old_ocean, 545, "The Old Ocean"), #411d984e-413e-4167-bb8c-c9e52572874e-2_A-BleachedCopse
+    lname.seastarplusplus_oldocean_entranceclam: ACTLocationData(rname.old_ocean, 561, "The Old Ocean"), #6df4f101-e0f2-4147-94e8-54235e8b803f-2_B-GrandCourtyard
+    lname.spongeplus_oldocean_entrance: ACTLocationData(rname.old_ocean, 563, "The Old Ocean"), #9cd5413b-91c2-421a-92de-8a703922f888-2_B-GrandCourtyard
+    lname.sanddollar_oldocean_citywall: ACTLocationData(rname.old_ocean, 571, "The Old Ocean"), #b27f8f08-2a6d-4f78-8ef5-ca01d2b968ef-2_B-GrandCourtyard
+    lname.usedbandageplus_oldocean_citywall: ACTLocationData(rname.old_ocean, 579, "The Old Ocean"), #5988e9dd-dc40-4f00-af63-66da9db0e7b4-2_B-GrandCourtyard
+    lname.cockleplus_oldocean_snaileast: ACTLocationData(rname.old_ocean, 582, "The Old Ocean"), #3e336fbb-9830-4772-a1b3-55dc039380dd-2_B-GrandCourtyard
+    lname.anothercrab_oldocean_elevator: ACTLocationData(rname.old_ocean, 588, "The Old Ocean"), #b7757de2-ce70-474e-a332-cef609bdf42f-2_B-GrandCourtyard
+    lname.sanddollar_oldocean_easternbuilding: ACTLocationData(rname.old_ocean, 592, "The Old Ocean"), #4babc398-17b9-4197-958e-c6bebc12a6c6-2_B-GrandCourtyard
+    lname.phytoplanktonplus_oldocean_clam: ACTLocationData(rname.old_ocean, 600, "The Old Ocean"), #a9ac0a98-889e-4138-a62b-0d59f63af118-2_B-GrandCourtyard
+    lname.musselplusplus_oldocean_woodplank: ACTLocationData(rname.old_ocean, 601, "The Old Ocean"), #df538a5c-9108-4210-8b9d-89e777116ec4-2_B-GrandCourtyard
+    lname.whelkplusplus_oldocean_mantis: ACTLocationData(rname.old_ocean, 604, "The Old Ocean"), #21387127-4e04-4017-bb58-3aafb9537876-2_B-GrandCourtyard
+    lname.fruitstickerplus_oldocean_island: ACTLocationData(rname.old_ocean, 625, "The Old Ocean"),
+    #602a241b-4901-4542-bd7b-f5bce8a9e383-2_A-BleachedCopse
 
     ##### costume locations
     lname.captain_costume_pickup: ACTLocationData(rname.central_shallows, 43, "Central Shallows"), #7c307763-a7b4-4e81-88d6-e1baf1b04608-2_B-ShallowsBigSand
     lname.clown_costume_pickup: ACTLocationData(rname.sands_between, 140,"The Sands Between"), #cd2d0535-6c06-4530-bf60-afbffc2d5086-2_A-OOGroveRadius
     lname.sunlight_costume_pickup: ACTLocationData(rname.secluded_ridge, 198, "The Sands Between - Secluded Ridge"), #35aa72f2-fa50-4efc-b600-b597382ed877-2_A-OOGroveRadius
-    lname.intern_costume_pickup: ACTLocationData(rname.grove_village, 296, "Expired Grove - Village"), #4ba7f2ff-ff35-4d74-b5ac-d9c59fe1c94d-2_C-Village
+    lname.intern_costume_pickup: ACTLocationData(rname.grove_village, 296, "Expired Grove - Village"), #57a328a3-94f4-406c-90de-bdcd1be7d69b-2_C-Village
     lname.cowfishboy_costume_pickup: ACTLocationData(rname.flotsam_vale, 348, "Flotsam Vale"), #b1f8794b-d43d-41b9-827a-75bb4c7a57bf-NickGym
     lname.bluecollar_costume_pickup: ACTLocationData(rname.scuttleport, 430, "Scuttleport"), #f37cb96e-df05-4aed-b2b5-7d8d5af32483-NickGym
     lname.krillionaire_costume_pickup: ACTLocationData(rname.unfathom, 490, "The Unfathom"), #c762c7f8-33b6-4701-9f4c-7ad7938a5d11-2_B-DarkCanyon
     lname.exiledflame_costume_pickup: ACTLocationData(rname.unfathom, 507, "The Unfathom"), #1b7cb531-3a0a-4957-ab59-da5c9f1da705-2_B-DarkCanyon
-    lname.drkril_costume_pickup: ACTLocationData(rname.old_ocean, 551, "The Old Ocean"), #d5fed7e0-cd33-4a81-9688-1e7ca948139f-2_A-BleachedCopse
+    lname.drkril_costume_pickup: ACTLocationData(rname.old_ocean, 551, "The Old Ocean"), #ecc223b8-902c-4d66-b01b-24728ccb7d4e-2_A-BleachedCopse
 
     ##### non-boss adaptation locations
     lname.urchin_toss_quest: ACTLocationData(rname.new_carcinia, 85,"New Carcinia"), #AUTO NEEDS TO MAKE A CUSTOM SCRIPT

--- a/worlds/another_crab/logic.py
+++ b/worlds/another_crab/logic.py
@@ -27,6 +27,92 @@ if TYPE_CHECKING:
 
 
 
+#Check if regions are accessible based on current glitch category and items (try to only invoke options in rules)
+
+def is_slacktide_before_accessible(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return state.can_reach_location(lname.nephro, player) or are_skips_allowed(options)
+    
+def is_reefs_edge_accessible(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return is_reefs_edge_accessible_vanilla(state, player) or can_magista_skip(options, state, player)
+
+def is_reefs_edge_accessible_vanilla(state: CollectionState, player: int) -> bool:
+    return state.has_all({iname.fishing_line, iname.pristine_pearl}, player) and state.can_reach_location(lname.magista, player)
+ 
+# This allows I-beam/decoy (skips), or CAL (glitch) to enter cave
+def is_moonsnail_accessible(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return (state.has(iname.fishing_line, player) or are_skips_allowed(options)) and can_pink_crab(options, state, player)
+    
+def is_post_ceviche_accessible(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return state.can_reach_location(lname.ceviche_sisters, player) or can_sisters_skip(options, state, player)
+    
+def is_consortium_accessible_vale(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return can_big_boost_jump(options, state, player) and state.can_reach_region(rname.flotsam_vale, player)
+    
+def is_consortium_accessible_grove(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return (is_consortium_accessible_grove_vanilla(state,player) or is_consortium_accessible_grove_skips(options,state,player) or can_CAL(options, state, player)) and state.can_reach_region(rname.grove_main, player)
+    
+def is_consortium_accessible_grove_skips(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return state.has_all({iname.fishing_line, iname.fork},player) and are_skips_allowed(options)
+
+def is_consortium_accessible_grove_vanilla(state: CollectionState, player: int) -> bool:
+    return state.has_all({iname.mantis_punch, iname.fishing_line},player)
+    
+def is_southern_town_ridge_accessible(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return is_southern_town_ridge_accessible_restricted(options, state, player) or state.has(iname.eelectrocute, player)
+    
+def is_southern_town_ridge_accessible_restricted(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return state.has(iname.razor_blade,player) and can_CAL(options, state, player)
+    
+def is_secluded_ridge_accessible(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return state.has(iname.mantis_punch, player) or are_skips_allowed(options)
+    
+def is_secluded_ridge_eel_accessible(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return state.has(iname.eelectrocute, player) or can_CAL(options, state, player)
+
+
+#Check if specific skips are executable
+#Magista skip
+def can_magista_skip(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return (can_magista_skip_grapple(options, state, player) or can_magista_skip_grappleless(options, state, player)) and options.goal != "magista" 
+
+def can_magista_skip_grapple(options: ACTGameOptions, state: CollectionState, player: int) -> bool:   
+    return state.has(iname.fishing_line, player) and are_skips_allowed(options)
+    
+def can_magista_skip_grappleless(options: ACTGameOptions, state: CollectionState, player: int) -> bool: #may be possible without CAL
+    return can_CAL(options, state, player) and can_shell_clip(options, state, player) 
+    
+#Sisters skip (check if other items behind sisters skip)
+def can_sisters_skip(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return state.has_any([iname.fork, iname.streamline], player) and state.has(iname.fishing_line, player) and are_skips_allowed(options)
+    
+#Can bypass/kill pink crab by moonsnail
+def can_pink_crab(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return can_reach_msg_dmg_shells(state,player) or  has_adaptation(state,player) or can_shell_clip(options, state, player)
+
+#Check if specific tricks are executable
+#CAL
+def can_CAL(options: ACTGameOptions, state: CollectionState, player: int) ->  bool:
+    return state.has(iname.fork, player) and are_glitches_allowed(options)
+    
+#Shell Clip (clip may be possible with other shells, need to check)
+def can_shell_clip(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return state.has(sname.soda_can, player) and are_glitches_allowed(options) 
+    
+#Bombs Away or Decoy
+def can_boost_jump(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return (can_bombs_away(state, player) or can_decoy(state, player)) and are_skips_allowed(options)
+
+#Bombs Away or Matrioshka
+def can_big_boost_jump(options: ACTGameOptions, state: CollectionState, player: int) -> bool:
+    return (can_bombs_away(state, player) or state.has(sname.matryoshka_large,player)) and are_skips_allowed(options)
+
+
+#Check if glitch category is one of several 
+def are_skips_allowed(options: ACTGameOptions) -> bool:
+    return options.logic_rules != "vanilla"
+    
+def are_glitches_allowed(options: ACTGameOptions) -> bool:
+    return options.logic_rules == "restricted" or options.logic_rules == "unrestricted"
 
 
 #Checks to see if the player can logically consistently deal damage
@@ -35,7 +121,6 @@ def can_deal_damage_hard(state: CollectionState,player:int) -> bool:
 
 def can_deal_damage_easy(state: CollectionState,player:int) -> bool:
     return can_magic_damage(state,player) | can_atk_damage_shell(state,player) | state.has(iname.fork,player)
-
 
 def can_rolling_attack(state: CollectionState, player: int) -> bool:
     return can_reach_rolling_shells(state,player) and (state.has(iname.lil_isopod,player,2))

--- a/worlds/another_crab/names/location_names.py
+++ b/worlds/another_crab/names/location_names.py
@@ -106,7 +106,6 @@ clothesclaw_grovemain_choccymilk = "Clothesclaw (Expired Grove Main - Chocolate 
 breadclaw_grovemain_insidetire = "Breadclaw (Expired Grove Main - Inside Tire Archway)"
 chipclaw_grovemain_sniper = "Chipclaw (Expired Grove Main - East Sniper Ledge)"
 hairclaw_grovemain_milkurchins = "Hairclaw (Expired Grove Main - Milk Carton Urchins)"
-breadclaw_grovemain_smallhall = "Breadclaw (Expired Grove Main - Small Connecting Hallway)"
 chipclaw_grovemain_apples = "Chipclaw (Expired Grove Main - Rotten Apple Cores)"
 chipclaw_grovemain_sodacans = "Chipclaw (Expired Grove Main - Shopping Cart Soda Cans)"
 hairclaw_grovemain_moonshine = "Hairclaw (Expired Grove Main - Shopping Cart Moonshine)"
@@ -119,6 +118,8 @@ breadclaw_grovemain_oilgrapple = "Breadclaw (Expired Grove Main - Grapple Near T
 clothesclaw_grovemain_mantisfish = "Clothesclaw (Expired Grove Main - Fishing Near Mantis Block)"
 hairclaw_grovemain_fishing = "Hairclaw (Expired Grove Main - Hidden Fishing Near Milk Carton)"
 clothesclaw_grovemain_riverfish = "Clothesclaw (Expired Grove Main - River Fishing Near Carbonara Waterfall)"
+clothesclaw_grovemain_waterfall = "Clothesclaw (Expired Grove Main - Behind Waterfall Near Lycanthrope)"
+hairclaw_grovemain_afternets = "Hairclaw (Expired Grove Main - Ledge After Grapple Nets)"
 
 breadclaw_grovevillage_oildrum = "Breadclaw (Expired Grove Village - After Oil Drum)"
 breadclaw_grovevillage_bottle1 = "Breadclaw (Expired Grove Village - In Bottle Near Cart Mantis Block 1)"
@@ -263,6 +264,7 @@ stapleclaw_oldocean_eastbuilding = "Stapleclaw (The Old Ocean - Ledge Outside Ea
 carclaw_oldocean_camtschapath = "Carclaw (The Old Ocean - Pathway to Camtscha's Arena)"
 stapleclaw_oldocean_camtschastairs = "Stapleclaw (The Old Ocean - Large Staircase in Front of Camtscha Arena)"
 carclaw_oldocean_middlebuilding = "Carclaw (The Old Ocean - Clam in Middle Building)"
+paperclaw_oldocean_upperhouse = "Paperclaw (The Old Ocean - Upper Floor of House Near Cork)"
 
 # upgrade item locations
 bloodstar_shallows_help = "Bloodstar Limb (Central Shallows - Help a Crab)" # the bloodstar limb acquired from helping the surrounded crab in the shallows
@@ -367,6 +369,7 @@ sharkegg_ridge_broomspire = "Shark Egg (Secluded Ridge - Broom Spire Peak)"
 
 barbedhook_trashbin_eelgrapple = "Barbed Hook (Trashbin Plateau - Eelectrocute Grapple Path)"
 
+barbedhook_grovemain_entranceparkour = "Barbed Hook (Expired Grove Main - Parkour at Grove Entrance"
 barbedhook_grovemain_sniper = "Barbed Hook (Expired Grove Main - Next to Sniper Crab)"
 barbedhook_grovemain_riverledge = "Barbed Hook (Expired Grove Main - Ledge Near Gunk River)"
 barbedhook_grovemain_riversand = "Barbed Hook (Expired Grove Main - In Sand Near Gunk River)"
@@ -374,7 +377,6 @@ barbedhook_grovemain_lichenthrope = "Barbed Hook (Expired Grove Main - Behind Di
 barbedhook_grovemain_lichenthropeeast = "Barbed Hook (Expired Grove Main - Ledge East of Lichenthrope)"
 barbedhook_grovemain_sodacans = "Barbed Hook (Expired Grove Main - Crushed Soda Cans)"
 barbedhook_grovemain_acrossriver = "Barbed Hook (Expired Grove Main - Ledge Across Gunk River)"
-barbedhook_grovemain_afternets = "Barbed Hook (Expired Grove Main - Ledge After Grapple Nets)"
 barbedhook_grovemain_cartledge = "Barbed Hook (Expired Grove Main - Ledge After Shopping Cart)"
 barbedhook_grovemain_cartledgebottle = "Barbed Hook (Expired Grove Main - Bottles on Ledge After Shopping Cart)"
 barbedhook_grovemain_paperplate = "Barbed Hook (Expired Grove Main - Paper Plate Near River)"
@@ -382,7 +384,10 @@ barbedhook_grovemain_oildrum = "Barbed Hook (Expired Grove Main - Main Pathway A
 barbedhook_grovemain_canopy = "Barbed Hook  (Expired Grove Main - Carton Canopy)"
 barbedhook_grovemain_drumtop = "Barbed Hook (Expired Grove Main - Near Top of Oil Drum)"
 barbedhook_grovemain_carts = "Barbed Hook (Expired Grove Main - Shopping Cart Buildings)"
+barbedhook_grovemain_platebottle = "Barbed Hook (Expired Grove Main - Bottle Near Paper Plate)"
+barbedhook_grovemain_cartledgebottle2 = "Barbed Hook (Expired Grove Main - Bottles Over River From Shopping Cart)"
 sharkegg_grovemain_mantis = "Shark Egg (Expired Grove Main - Mantis Block on Left Path)"
+barbedhook_grovemain_smallhall = "Barbed Hook (Expired Grove Main - Small Connecting Hallway)"
 
 barbedhook_grovevillage_heikea = "Barbed Hook (Expired Grove Village - In Cave After Heikea)"
 barbedhook_grovevillage_cartfish = "Barbed Hook (Expired Grove Village - Hidden Fishing Near Shopping Cart Mantis Block)"
@@ -628,6 +633,7 @@ salpplus_plains_entrance = "Salp+ (Abyssal Plains - Above Entrance)"
 anothercrab_plains_shortcutclam = "Another Crab (Abyssal Plains - Clam On Ledge East of Shortcut)"
 seacucumber_plains_entrance = "Sea Cucumber (Abyssal Plains - North of Entrance)"
 fruitsticker_plains_entrance = "Fruit Sticker (Abyssal Plains - North of Entrance)"
+stapleclaw_unfathom_centreclam = "Stapleclaw (Abyssal Plains - North of Second CD)"
 
 sanddollar_oldocean_ledge = "Sand Dollar (The Old Ocean - Ledge North of Second Island)"
 barnacleplusplus_oldocean_styrofoam = "Barnacle++ (The Old Ocean - Across Styrofoam Block Hooks)"
@@ -641,6 +647,7 @@ sanddollar_oldocean_easternbuilding = "Sand Dollar (The Old Ocean - Inside Easte
 phytoplanktonplus_oldocean_clam = "Phytoplankton+ (The Old Ocean - Clam Inside Eastern Building)"
 musselplusplus_oldocean_woodplank = "Mussel++ (The Old Ocean - Clam in Secret Area Under Wooden Planks)"
 whelkplusplus_oldocean_mantis = "Whelk++ (The Old Ocean - Behind Mantis Punch Wall)"
+fruitstickerplus_oldocean_island = "Fruit Sticker+ (The Old Ocean - Beyond Lone House on Floating Island)"
 
 # costume locations
 captain_costume_pickup = "Captain Costume (Central Shallows - Near Nephro Spawn)"

--- a/worlds/another_crab/names/location_names.py
+++ b/worlds/another_crab/names/location_names.py
@@ -564,6 +564,7 @@ rustynail_flotsamvale_brokenbutane = "Rusty Nail (Flotsam Vale - In Gunk Under B
 sinker_flotsamvale_woodplatform = "Sinker (Flotsam Vale - Wooden Platform Above Sludge Steamroller)"
 mussel_flotsamvale_woodplatform = "Mussel (Flotsam Vale - Wooden Platform Above Sludge Steamroller)"
 rustynail_flotsamvale_steamroller = "Rusty Nail (Flotsam Vale - In Gunk Near Sludge Steamroller)"
+barnacle_flotsamvale_steamroller =  "Barnacle (Flotsam Vale - On Roof Above Sludge Steamroller)"
 limpet_flotsamvale_trashpile = "Limpet (Flotsam Vale - Trash Pile Near Sludge Steamroller)"
 fruitsticker_flotsamvale_westbutane = "Fruit Sticker (Flotsam Vale - Butane Tanks West of Sludge Steamroller)"
 seacucumber_flotsamvale_westbutane = "Sea Cucumber (Flotsam Vale - Butane Tanks West of Sludge Steamroller)"

--- a/worlds/another_crab/names/region_names.py
+++ b/worlds/another_crab/names/region_names.py
@@ -22,11 +22,19 @@ carcinia_ruins = "New Carcinia Ruins" # adding this because it will probably nee
 
 # sub regions
 slacktide_before = "Fort Slacktide - Before Destruction" # slacktide before the player gets the pearl and slacktide goes crazy
+central_shallows_grapple = "Central Shallows - Items Behind Grapple" # a selection of items in slacktide which can be obtained without the grapple using parkour
 slacktide_after = "Fort Slacktide - After Destruction" # slacktide after the player gets the pearl and slacktide goes crazy
+reefs_edge_grapple = "Reef's Edge - Items Behind Grapple" # a selection of items in reef's edge which can be obtained without grapple using parkour
 post_pag = "The Sands Between - Post Pagurus" # after the pagurus map piece is returned
-secluded_ridge = "Secluded Ridge & Trashbin Plateau" # area in sands that requires mantis punch to access
+southern_town_ridge = "Southern Town Ridge" # area in sands by company town which usually requires eelectrocute to access
+secluded_ridge = "Secluded Ridge" # area in sands that usually requires mantis punch to access
+secluded_ridge_eel = "Secluded Ridge - Past Eelectrocute" # sub-region of secluded ridge that usually requires eelectrocute to access
+trashbin_plateau = "Trashbin Plateau" 
 grove_main = "Expired Grove - Main" # grove up to heikea
+grove_raised_platforms = "Expired Grove - Raised Platforms"
 grove_village = "Expired Grove - Village" # grove path to topoda
-vale_main = "Flotsam Vale - Main" # flotsam vale before getting all map pieces
+#vale_main = "Flotsam Vale - Main" # flotsam vale before getting all map pieces 
+post_ceviche = "Flotsam Vale - Post Ceviche Sisters" # items in flotsam vale only available after killing ceviche sisters in vanilla
+consortium_arena = "Flotsam Vale - Consortium Arena" # linked to grove_village and flotsam vale
 scuttleport = "Scuttleport" # part of the flotsam vale region, but specifically the area where the player finds voltai
 plains = "Abyssal Plains" # the last big area in the unfathom just before the inkerton fight

--- a/worlds/another_crab/options.py
+++ b/worlds/another_crab/options.py
@@ -38,16 +38,18 @@ class AllowForkless(Choice):
     option_forkless_hard = 2
     default = 0
 
-# class LogicRules(Choice):
-#    """Set the preferred logic rules for your game
-#    - Restricted: Standard logic, no skips/glitches required to complete goal.
-#    - No Major Glitches: Allows for {list of easy logic rules here} to be needed to complete goal.
-#    - Unrestricted: In addition to the list under No Major Glitches allows for {list of more advanced rules here} to be needed to complete goal."""
-#    display_name:str = "Logic Rules"
-#    option_restricted = 0
-#    option_no_major_glitches = 1
-#    option_unrestricted = 2
-#    default = 0
+class LogicRules(Choice):
+    """Set the preferred logic rules for your game
+    - Vanilla: Standard logic, no skips/glitches required to complete the goal.
+    - Glitchless: Allows for the following parkour-based skips (list of glitchless rules here) to be required to complete the goal.
+    - Restricted: In addition to the list under glitchless, allows for (list of easy glitches/skips here) to be required to complete the goal.
+    - Unrestricted: In addition to the lists under both glitchless and restricted, allows for (list of hard glitches/skips here) to be required to complete the goal."""
+    display_name:str = "Logic Rules"
+    option_vanilla = 0
+    option_glitchless = 1
+    option_restricted = 2
+    option_unrestricted = 3
+    default = 0
  
 class ShelleportLocation(Choice):
     """Choose where the Shelleport (fast travel) skill location is set
@@ -108,7 +110,7 @@ class ACTGameOptions(PerGameCommonOptions):
     goal: Goal
     fork_location: ForkLocation
     allow_forkless: AllowForkless
-    #logic_rules: LogicRules
+    logic_rules: LogicRules
     shelleport_location: ShelleportLocation
     fishing_line_location: FishingLineLocation
     randomshells: RandomShells

--- a/worlds/another_crab/regions.py
+++ b/worlds/another_crab/regions.py
@@ -16,11 +16,14 @@ ACT_regions: Dict[str, Set[str]] = {
         rname.central_shallows
     },
     rname.central_shallows: {
+        rname.central_shallows_grapple,
         rname.slacktide_before,
         sname.soda_can
     },
+    rname.central_shallows_grapple: set(),
     rname.slacktide_before: {
         rname.snail_cave,
+        rname.reefs_edge,
         sname.soda_can,
         sname.coconut,
         sname.banana_peel,
@@ -34,16 +37,17 @@ ACT_regions: Dict[str, Set[str]] = {
         sname.party_hat
     },
     rname.slacktide_after: {
-        rname.reefs_edge,
         sname.teacup
     },
     rname.reefs_edge: {
+        rname.reefs_edge_grapple,
         rname.new_carcinia,
         sname.salt_shaker,
         sname.thimble,
         sname.tennis_ball,
         sname.sauce_nozzle
     },
+    rname.reefs_edge_grapple: set(),
     rname.new_carcinia: {
         rname.sands_between,
         sname.f_key,
@@ -61,6 +65,8 @@ ACT_regions: Dict[str, Set[str]] = {
     rname.sands_between: {
         rname.post_pag,
         rname.secluded_ridge,
+        rname.trashbin_plateau,
+        rname.southern_town_ridge,
         rname.grove_main,
         rname.flotsam_vale,
         sname.coffee_pod,
@@ -78,18 +84,27 @@ ACT_regions: Dict[str, Set[str]] = {
         sname.lil_red_cup
     },
     rname.post_pag: set(),
-    rname.secluded_ridge: set(),
+    rname.secluded_ridge: {
+        rname.secluded_ridge_eel
+    },
+    rname.secluded_ridge_eel: set(), 
+    rname.trashbin_plateau: set(),
+    rname.southern_town_ridge: set(),
     rname.grove_main: {
         rname.grove_village,
+        rname.grove_raised_platforms,
+        rname.consortium_arena,
         sname.coffee_mug
     },
+    rname.grove_raised_platforms: set(),
     rname.grove_village: {
         sname.skull,
         sname.ham_tin,
         sname.crab_husk
     },
     rname.flotsam_vale: {
-        rname.grove_village,
+        rname.post_ceviche,
+        rname.consortium_arena,
         rname.scuttleport,
         sname.boxing_glove,
         sname.spring,
@@ -97,6 +112,8 @@ ACT_regions: Dict[str, Set[str]] = {
         sname.tissue_box,
         sname.cardboard_box
     },
+    rname.post_ceviche: set(),
+    rname.consortium_arena: set(),
     rname.scuttleport: {
         rname.pinbarge,
         sname.dumptruck,

--- a/worlds/another_crab/rules.py
+++ b/worlds/another_crab/rules.py
@@ -803,6 +803,10 @@ def set_location_rules(world: "ACTWorld") -> None:
         # grapple + eelectrocute (will add metal shell later)
         set_rule(multiworld.get_location(lname.oldworldwhorl_scuttleport_eelectrocute, player),
                 lambda state: state.has_all({iname.fishing_line, iname.eelectrocute}, player))
+                
+        # grapple and spearfishing
+        set_rule(multiworld.get_location(lname.mussel_scuttleport_magnetfish,player),
+                lambda state: state.has_all({iname.fishing_line, iname.spearfishing}, player))
         
         if options.goal != "voltai" and options.goal != "roland":
         
@@ -830,4 +834,8 @@ def set_location_rules(world: "ACTWorld") -> None:
                 # mantis punch
                 set_rule(multiworld.get_location(lname.whelkplusplus_oldocean_mantis, player),
                         lambda state: state.has(iname.mantis_punch, player))
+                        
+                # grapple
+                set_rule(multiworld.get_location(lname.fruitstickerplus_oldocean_island, player),
+                        lambda state: state.has(iname.fishing_line,player))
                         

--- a/worlds/another_crab/rules.py
+++ b/worlds/another_crab/rules.py
@@ -22,39 +22,64 @@ if TYPE_CHECKING:
 #}
 
 
-
 def set_region_rules(world: "ACTWorld") -> None:
   multiworld = world.multiworld
   player = world.player
   options = world.options
   #logic.set_options(world.options)
 
+  multiworld.get_entrance("Central Shallows -> Central Shallows - Items Behind Grapple", player).access_rule = \
+    lambda state: (state.has(iname.fishing_line,player) or logic.are_skips_allowed(options))
+    
   multiworld.get_entrance("Central Shallows -> Fort Slacktide - Before Destruction", player).access_rule = \
-    lambda state: state.can_reach_location(lname.nephro, player)
+    lambda state: logic.is_slacktide_before_accessible(options, state, player)
 
   multiworld.get_entrance("Fort Slacktide - Before Destruction -> Moon Snail's Cave", player).access_rule = \
-    lambda state: state.has(iname.fishing_line, player)
-  
-  #add_rule(multiworld.get_entrance("Fort Slacktide - Before Destruction -> Moon Snail's Cave",player),
-    #lambda state: state.has_any({logic.can_reach_msg_dmg_shells(state,player), logic.has_adaptation(state,player)},player))
+    lambda state: logic.is_moonsnail_accessible(options, state, player)
    
   multiworld.get_entrance("Moon Snail's Cave -> Fort Slacktide - After Destruction", player).access_rule = \
-    lambda state: state.has(iname.pristine_pearl, player)
+    lambda state: state.has(iname.pristine_pearl, player)  
     
-  multiworld.get_entrance("Fort Slacktide - After Destruction -> Reef's Edge", player).access_rule = \
-    lambda state: state.has_all({iname.fishing_line, iname.pristine_pearl}, player) & state.can_reach_location(lname.magista,player)
+  multiworld.get_entrance("Fort Slacktide - Before Destruction -> Reef's Edge", player).access_rule = \
+    lambda state: logic.is_reefs_edge_accessible(options, state, player)
     
-  multiworld.get_entrance("The Sands Between -> Secluded Ridge & Trashbin Plateau", player).access_rule = \
+  multiworld.get_entrance("Reef's Edge -> Reef's Edge - Items Behind Grapple", player).access_rule = \
+  lambda state: (state.has(iname.fishing_line,player) or logic.are_skips_allowed(options))
+    
+  multiworld.get_entrance("The Sands Between -> Secluded Ridge", player).access_rule = \
+    lambda state: logic.is_secluded_ridge_accessible(options, state, player)
+    
+  multiworld.get_entrance("Secluded Ridge -> Secluded Ridge - Past Eelectrocute", player).access_rule = \
+    lambda state: logic.is_secluded_ridge_eel_accessible(options, state, player)
+    
+  multiworld.get_entrance("The Sands Between -> Trashbin Plateau", player).access_rule = \
     lambda state: state.has(iname.mantis_punch, player)
+    
+  multiworld.get_entrance("The Sands Between -> Southern Town Ridge", player).access_rule = \
+    lambda state: logic.is_southern_town_ridge_accessible(options, state, player)
+    
+  multiworld.get_entrance("Expired Grove - Main -> Flotsam Vale - Consortium Arena",player).access_rule = \
+    lambda state: logic.is_consortium_accessible_grove(options, state, player)
+    
+  multiworld.get_entrance("Expired Grove - Main -> Expired Grove - Raised Platforms",player).access_rule = \
+    lambda state: logic.is_consortium_accessible_grove(options, state, player)
+  
+  multiworld.get_entrance("Flotsam Vale -> Flotsam Vale - Post Ceviche Sisters", player).access_rule = \
+    lambda state: logic.is_post_ceviche_accessible(options, state, player)
+    
+  multiworld.get_entrance("Flotsam Vale -> Flotsam Vale - Consortium Arena", player).access_rule = \
+    lambda state: logic.is_consortium_accessible_vale(options, state, player)
     
   multiworld.get_entrance("Flotsam Vale -> Scuttleport", player).access_rule = \
     lambda state: state.has_all({iname.map_piece_fv, iname.map_piece_heikea, iname.map_piece_pagurus}, player)
     
+  if options.randomshells and options.goal != "magista" :
+    add_rule(multiworld.get_entrance("Flotsam Vale -> Scuttleport",player),lambda state: state.has(sname.plug_fuse, player))
+    
   multiworld.get_entrance("Scuttleport -> Pinbarge", player).access_rule = \
     lambda state: state.has(iname.eelectrocute, player)
   
-  if options.randomshells and options.goal != "magista" :
-    add_rule( multiworld.get_entrance("Flotsam Vale -> Scuttleport",player),lambda state: state.has(sname.plug_fuse, player))
+
   
   #Matryoshka Shell Rules
   #multiworld.get_entrance("Tide Pools -> Matryoshka Medium",player).access_rule = \
@@ -70,6 +95,7 @@ def set_region_rules(world: "ACTWorld") -> None:
 
 #    set_rule(multiworld.get_location(lname.nephro, player),
 #             lambda state: state.can_reach_region())
+
 
 def set_location_rules(world: "ACTWorld") -> None:
   multiworld = world.multiworld
@@ -99,7 +125,7 @@ def set_location_rules(world: "ACTWorld") -> None:
     
     if options.goal != "magista":
         set_rule(multiworld.get_location(lname.pagurus, player),
-                lambda state: state.has(iname.fork,player))
+                lambda state: (state.has(iname.fork,player) or logic.are_skips_allowed(options))) #allow pagurus quick kill if not vanilla
         
         set_rule(multiworld.get_location(lname.lichenthrope, player),
                 lambda state: state.has(iname.fork,player))
@@ -166,7 +192,7 @@ def set_location_rules(world: "ACTWorld") -> None:
     
     if options.goal != "magista":
         set_rule(multiworld.get_location(lname.pagurus, player),
-                lambda state: logic.can_deal_damage_easy(state,player))
+                lambda state: (logic.can_deal_damage_easy(state,player) or logic.are_skips_allowed(options)))
         
         set_rule(multiworld.get_location(lname.lichenthrope, player),
                 lambda state: logic.can_deal_damage_easy(state,player))
@@ -230,7 +256,7 @@ def set_location_rules(world: "ACTWorld") -> None:
     
     if options.goal != "magista":
         set_rule(multiworld.get_location(lname.pagurus, player),
-                lambda state: logic.can_deal_damage_hard(state,player))
+                lambda state: (logic.can_deal_damage_hard(state,player) or logic.are_skips_allowed(options)))
         
         set_rule(multiworld.get_location(lname.lichenthrope, player),
                 lambda state: logic.can_deal_damage_hard(state,player))
@@ -299,27 +325,15 @@ def set_location_rules(world: "ACTWorld") -> None:
             lambda state: state.has_all({iname.spearfishing, iname.fishing_line}, player))
 
 # ---- Central Shallows ----
- # grapple
-  set_rule(multiworld.get_location(lname.breadclaw_shallows_sandcastle, player),
-            lambda state: state.has(iname.fishing_line, player))
-    
-  set_rule(multiworld.get_location(lname.breadclaw_shallows_eastledge, player),
-            lambda state: state.has(iname.fishing_line, player))
-    
-  set_rule(multiworld.get_location(lname.hairclaw_shallows_turret, player),
-            lambda state: state.has(iname.fishing_line, player))
-    
+ # grapple   
   set_rule(multiworld.get_location(lname.chipclaw_shallows_sandcastle, player),
             lambda state: state.has(iname.fishing_line, player))
     
   set_rule(multiworld.get_location(lname.bloodstar_shallows_clam, player),
             lambda state: state.has(iname.fishing_line, player))
     
-  set_rule(multiworld.get_location(lname.sponge_shallows_puffer, player),
-            lambda state: state.has(iname.fishing_line, player))
-    
   set_rule(multiworld.get_location(lname.anothercrab_shallows_pillar, player),
-            lambda state: state.has(iname.fishing_line, player))
+            lambda state: state.has(iname.fishing_line, player) or logic.can_CAL(options,state,player))
     
   set_rule(multiworld.get_location(lname.sanddollar_shallows_arch, player),
             lambda state: state.has(iname.fishing_line, player))
@@ -354,10 +368,10 @@ def set_location_rules(world: "ACTWorld") -> None:
             lambda state: state.has(iname.fishing_line, player))
     
   set_rule(multiworld.get_location(lname.barnacle_slacktide_bigurchin, player),
-            lambda state: state.has(iname.fishing_line, player))
+            lambda state: (state.has(iname.fishing_line, player) or logic.can_boost_jump(options, state, player)))
     
   set_rule(multiworld.get_location(lname.rustynail_slacktide_bigurchin, player),
-            lambda state: state.has(iname.fishing_line, player))
+            lambda state: state.has(iname.fishing_line, player) or (logic.can_big_boost_jump(options, state, player) and state.can_reach_region(rname.slacktide_after,player)))
     
   set_rule(multiworld.get_location(lname.chipclaw_slacktide_brokenwall, player),
             lambda state: state.has(iname.fishing_line, player))
@@ -373,17 +387,7 @@ def set_location_rules(world: "ACTWorld") -> None:
             lambda state: state.has_all({iname.spearfishing, iname.fishing_line}, player))
 
   if options.goal != "magista":
-        # ---- Reef's Edge ----
-        # grapple
-        set_rule(multiworld.get_location(lname.breadclaw_reefsedge_thimblecrab, player),
-                lambda state: state.has(iname.fishing_line, player))
-        
-        set_rule(multiworld.get_location(lname.seastar_reefsedge_crabs, player),
-                lambda state: state.has(iname.fishing_line, player))
-        
-        set_rule(multiworld.get_location(lname.barbedhook_reefsedge_shortcut, player),
-                lambda state: state.has(iname.fishing_line, player))
-        
+        # ---- Reef's Edge ----        
         # mantis punch
         set_rule(multiworld.get_location(lname.seastarplus_reefsedge_pole, player),
                 lambda state: state.has(iname.mantis_punch, player))
@@ -563,20 +567,14 @@ def set_location_rules(world: "ACTWorld") -> None:
         set_rule(multiworld.get_location(lname.paperclaw_postpag_schain, player),
                 lambda state: state.has(iname.map_piece_pagurus, player))
 
-        # ---- Secluded Ridge ----
+
+        # ---- Secluded Ridge and Trashbin Plateau ----
         # grapple
-        set_rule(multiworld.get_location(lname.bobber_ridge_broomspire, player),
-                lambda state: state.has(iname.fishing_line, player))
-        
         set_rule(multiworld.get_location(lname.sharkegg_ridge_broomspire, player),
-                lambda state: state.has(iname.fishing_line, player))
-        
-        # eelectrocute
-        set_rule(multiworld.get_location(lname.anemoneplus_ridge_eel, player),
-                lambda state: state.has(iname.eelectrocute, player))
-        
-        set_rule(multiworld.get_location(lname.oldworldwhorl_ridge_eelclam, player),
-                lambda state: state.has(iname.eelectrocute, player))
+                lambda state: state.has(iname.mantis_punch, player) and (logic.can_CAL(options, state, player) or state.has(iname.fishing_line, player)))
+                
+        set_rule(multiworld.get_location(lname.bobber_ridge_broomspire, player),
+                lambda state: state.has_all({iname.mantis_punch,iname.fishing_line}, player))
         
         # spearfishing
         set_rule(multiworld.get_location(lname.clothesclaw_ridge_overlookfish, player),
@@ -584,11 +582,11 @@ def set_location_rules(world: "ACTWorld") -> None:
         
         set_rule(multiworld.get_location(lname.chipclaw_ridge_southfish, player),
                 lambda state: state.has(iname.spearfishing, player))
+          
+        set_rule(multiworld.get_location(lname.cockle_ridge_eelfish, player),
+                lambda state: state.has(iname.spearfishing, player))
 
         # spearfishing + eelectrocute
-        set_rule(multiworld.get_location(lname.cockle_ridge_eelfish, player),
-                lambda state: state.has_all({iname.spearfishing, iname.eelectrocute}, player))
-        
         set_rule(multiworld.get_location(lname.stapleclaw_trashbin_eelfish, player),
                 lambda state: state.has_all({iname.spearfishing, iname.eelectrocute}, player))
 
@@ -597,17 +595,8 @@ def set_location_rules(world: "ACTWorld") -> None:
                 lambda state: state.has_all({iname.fishing_line, iname.eelectrocute}, player))
         
         # ---- Expired Grove Main ----
-        # grapple
-        set_rule(multiworld.get_location(lname.chipclaw_grovemain_sniper, player),
-                lambda state: state.has(iname.fishing_line, player))
-        
+        # grapple        
         set_rule(multiworld.get_location(lname.hairclaw_grovemain_milkurchins, player),
-                lambda state: state.has(iname.fishing_line, player))
-        
-        set_rule(multiworld.get_location(lname.lumpsucker_grovemain_canopy, player),
-                lambda state: state.has(iname.fishing_line, player))
-        
-        set_rule(multiworld.get_location(lname.barbedhook_grovemain_canopy, player),
                 lambda state: state.has(iname.fishing_line, player))
         
         set_rule(multiworld.get_location(lname.breadclaw_grovemain_oilgrapple, player),
@@ -736,6 +725,9 @@ def set_location_rules(world: "ACTWorld") -> None:
         # ---- Flotsam Vale ----
 
         # spearfishing
+        set_rule(multiworld.get_location(lname.hairclaw_flotsamvale_APfish,player),
+                lambda state: state.has(iname.spearfishing, player))
+                
         set_rule(multiworld.get_location(lname.lamprey_flotsamvale_islandfish, player),
                 lambda state: state.has(iname.spearfishing, player))
         
@@ -816,6 +808,10 @@ def set_location_rules(world: "ACTWorld") -> None:
         
                 # ---- The Unfathom ----
 
+                # grapple
+                set_rule(multiworld.get_location(lname.tacklepouch_plains_grapplesnail,player),
+                        lambda state: state.has(iname.fishing_line,player) or logic.can_CAL(options,state,player))
+                
                 # spearfishing
                 set_rule(multiworld.get_location(lname.salp_unfathom_glowstickfish, player),
                         lambda state: state.has(iname.spearfishing, player))
@@ -834,3 +830,4 @@ def set_location_rules(world: "ACTWorld") -> None:
                 # mantis punch
                 set_rule(multiworld.get_location(lname.whelkplusplus_oldocean_mantis, player),
                         lambda state: state.has(iname.mantis_punch, player))
+                        


### PR DESCRIPTION
 - Added option to include glitches/skips into logic
 - All skips from original research now incorporated
 - Added several new sub-regions to account for this (including splitting trashbin plateau and secluded ridge)
 - Minor bugfixes (items not having necessary requirements/not being randomised)
 - Reformatted some location tags in locations.py to match location_names.py

 - Tested for expected behaviour by producing spoiler logs for runs with each logic setting and fork_early_local/forkless_easy
