### PR TITLE
Another Crab's Treasure: WebWorld Fix

### DIFF
--- a/worlds/another_crab/__init__.py
+++ b/worlds/another_crab/__init__.py
@@ -2,7 +2,7 @@ import math
 from typing import Dict, List, Any
 from Utils import visualize_regions
 from worlds.AutoWorld import WebWorld, World
-from BaseClasses import Region, ItemClassification, CollectionState
+from BaseClasses import Region, ItemClassification, CollectionState, Tutorial
 from Fill import fill_restrictive
 
 from .items import item_table, item_name_groups, item_name_to_id, filler_items, costume_items, trap_items, shell_items,item_limited_group, ACTItem, ACTItemData
@@ -16,6 +16,17 @@ from .names import location_names as lname, item_names as iname, region_names as
 class ACTWeb(WebWorld):
     theme: str = "ocean"
     game: str = "Another Crab's Treasure"
+
+    setup_en = Tutorial(
+        "Multiworld Setup Guide",
+        "A guide to setting up the Archipelago randomizer for Another Crab's Treasure.",
+        "English",
+        "setup_en.md",
+        "setup/en",
+        ["Automagic00"]
+    )
+
+    tutorials = [setup_en]
 
 class ACTWorld(World):
     """


### PR DESCRIPTION
## What is this fixing or adding?
Typically, when self-hosting the Archipelago website (e.g. using WebHost.py), all custom games in the custom_worlds folder will appear on the Supported Games page.

Another Crab's Treasure does not currently appear in the list because AP treats any WebWorld without a Tutorial as invalid. (For reference, see below permalink to the relevant AP source code.)

https://github.com/ArchipelagoMW/Archipelago/blob/09aba95c039f2d304c15466b7cff6f0ee8f12aa8/WebHost.py#L115-L116

This PR adds a Tutorial to the WebWorld so the game can appear in the Supported Games list.

## How was this tested?
By adding the updated AP world for ACT to the custom_worlds folder, and locally hosting the website using WebHost.py. Confirmed the game now appears on the Supported Games page.

## If this makes graphical changes, please attach screenshots.
<img width="1588" height="725" alt="WebHost - Another Crab&#39;s Treasure" src="https://github.com/user-attachments/assets/24d3a674-11e2-4123-8217-8784c523080e" />
