### PR TITLE
REPO: WebWorld Fix

### DIFF
--- a/worlds/repo/__init__.py
+++ b/worlds/repo/__init__.py
@@ -3,7 +3,7 @@ import time
 from typing import Dict, List, Any
 from Utils import visualize_regions
 from worlds.AutoWorld import WebWorld, World
-from BaseClasses import LocationProgressType, Region, ItemClassification, CollectionState
+from BaseClasses import LocationProgressType, Region, ItemClassification, CollectionState, Tutorial
 from Fill import fill_restrictive
 
 from .items import item_table, item_name_groups, item_name_to_id, filler_items, trap_items, REPOItem, REPOItemData,event_items
@@ -17,6 +17,17 @@ from .names import location_names as lname, item_names as iname, region_names as
 class REPOWeb(WebWorld):
     theme: str = "stone"
     game: str = "R.E.P.O"
+
+    setup_en = Tutorial(
+        "Multiworld Setup Guide",
+        "A guide to setting up the Archipelago randomizer for R.E.P.O.",
+        "English",
+        "setup_en.md",
+        "setup/en",
+        ["Automagic00"]
+    )
+
+    tutorials = [setup_en]
 
 class REPOWorld(World):
     


### PR DESCRIPTION
## What is this fixing or adding?
Same as [my PR for Another Crab's Treasure](https://github.com/Automagic00/Autos-Archipelagos/pull/30), but for REPO. When self-hosting the Archipelago website, REPO does not currently appear in the Supported Games list because [AP treats any WebWorld without a Tutorial as invalid](https://github.com/ArchipelagoMW/Archipelago/blob/09aba95c039f2d304c15466b7cff6f0ee8f12aa8/WebHost.py#L115-L116).

This PR adds a Tutorial to the WebWorld so the game can appear in the Supported Games list.

(Note that the [setup guide for REPO](https://github.com/Automagic00/Autos-Archipelagos/blob/REPOBranch/worlds/repo/docs/setup_en.md) is currently a copy of ACT's, so the website currently shows the ACT guide when clicking "Setup Guides" in the below screenshot.)

## How was this tested?
By adding the updated AP world for REPO to the custom_worlds folder, and locally hosting the website using WebHost.py. Confirmed the game now appears on the Supported Games page.

## If this makes graphical changes, please attach screenshots.
<img width="1531" height="216" alt="WebHost - REPO" src="https://github.com/user-attachments/assets/7b7b9ebf-438d-40c5-91cd-8a3a165427f9" />
